### PR TITLE
Switch to Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+member of the project.
+
+- [Erik Erlandson](https://github.com/erikerlandson)
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ libraryDependencies ++= Seq(
 ```
 
 ### Code of Conduct
-The `coulomb` project supports the [typelevel code of conduct](http://typelevel.org/conduct.html);
+The `coulomb` project supports the [Scala Code of Conduct](https://typelevel.org/code-of-conduct.html);
 all contributors are expected to respect this code.
 Any violations of this code of conduct should be reported to [the author](https://github.com/erikerlandson/).
 


### PR DESCRIPTION
Typelevel is [moving to the Scala Code of Conduct](https://typelevel.org/blog/2019/05/01/typelevel-switches-to-scala-code-of-conduct.html), and we're encouraging all member projects to switch.