### PR TITLE
remove preamble, as it appears to already be in runtime universe

### DIFF
--- a/coulomb-parser/src/main/scala/coulomb/parser/QuantityParser.scala
+++ b/coulomb-parser/src/main/scala/coulomb/parser/QuantityParser.scala
@@ -37,18 +37,7 @@ class QuantityParser private (private val qpp: coulomb.parser.infra.QPP[_]) exte
   @transient private lazy val lex = new coulomb.parser.lexer.UnitDSLLexer(qpp.unames, qpp.pfnames)
   @transient private lazy val parse = new coulomb.parser.parser.UnitDSLParser(qpp.nameToType)
 
-  @transient private lazy val unitDecls = qpp.decls.map { d => s"$d\n" }.mkString("")
-
-  @transient private lazy val imports = Seq(
-    "coulomb._",
-    "coulomb.define._",
-    "spire.math.Rational"
-  ).map { i => s"import $i\n" }.mkString("")
-
-  // figure out how to pre-compile this preamble
-  @transient private lazy val preamble = s"${imports}${unitDecls}"
-
-  @transient private lazy val toolbox = runtimeMirror(getClass.getClassLoader).mkToolBox()
+  @transient lazy val toolbox = runtimeMirror(getClass.getClassLoader).mkToolBox()
 
   /**
    * Parse an expression into a unit typed Quantity
@@ -69,7 +58,7 @@ class QuantityParser private (private val qpp: coulomb.parser.infra.QPP[_]) exte
     for {
       tok <- lex(quantityExpr)
       ast <- parse(tok).toTry
-      code <- Try { s"${preamble}($ast)${cast}" }
+      code <- Try { s"($ast)${cast}" }
       qeTree <- Try { toolbox.parse(code) }
       qeEval <- Try { toolbox.eval(qeTree) }
       qret <- Try { qeEval.asInstanceOf[Quantity[N, U]] }

--- a/coulomb-parser/src/main/scala/coulomb/parser/infra.scala
+++ b/coulomb-parser/src/main/scala/coulomb/parser/infra.scala
@@ -40,13 +40,13 @@ object unitops {
       new UnitTypeString[U] { val expr = utt.tpe.typeSymbol.fullName }
 
     implicit def evidenceMul[L, R](implicit udfL: UnitTypeString[L], udfR: UnitTypeString[R]): UnitTypeString[%*[L, R]] =
-      new UnitTypeString[%*[L, R]] { val expr = s"%*[${udfL.expr}, ${udfR.expr}]" }
+      new UnitTypeString[%*[L, R]] { val expr = s"coulomb.%*[${udfL.expr}, ${udfR.expr}]" }
 
     implicit def evidenceDiv[L, R](implicit udfL: UnitTypeString[L], udfR: UnitTypeString[R]): UnitTypeString[%/[L, R]] =
-      new UnitTypeString[%/[L, R]] { val expr = s"%/[${udfL.expr}, ${udfR.expr}]" }
+      new UnitTypeString[%/[L, R]] { val expr = s"coulomb.%/[${udfL.expr}, ${udfR.expr}]" }
 
     implicit def evidencePow[B, E](implicit udfB: UnitTypeString[B], e: XIntValue[E]): UnitTypeString[%^[B, E]] =
-      new UnitTypeString[%^[B, E]] { val expr = s"%^[${udfB.expr}, ${e.value}]" }
+      new UnitTypeString[%^[B, E]] { val expr = s"coulomb.%^[${udfB.expr}, ${e.value}]" }
   }
 }
 
@@ -72,83 +72,6 @@ private [coulomb] object infra {
     // low-priority rule above, and this won't work right.
     implicit def evidence0[T, V](implicit no: Evidence.Aux[T, V], vf: V =:= false): NoEvidence[T] =
       new NoEvidence[T] {}
-  }
-
-  trait SetInsert[E, S] {
-    type Out
-  }
-  object SetInsert {
-    type Aux[E, S, O] = SetInsert[E, S] { type Out = O }
-    implicit def evidence0[E]: Aux[E, HNil, E :: HNil] = new SetInsert[E, HNil] { type Out = E :: HNil }
-    implicit def evidence1[E, T <: HList]: Aux[E, E :: T, E :: T] =
-      new SetInsert[E, E :: T] { type Out = E :: T }
-    implicit def evidence2[E, H, T <: HList, O <: HList ](implicit
-        ne: E =:!= H,
-        rc: Aux[E, T, O]): Aux[E, H :: T, H :: O] =
-      new SetInsert[E, H :: T] { type Out = H :: O }
-  }
-
-  trait SetUnion[S1, S2] {
-    type Out
-  }
-  object SetUnion {
-    type Aux[S1, S2, O] = SetUnion[S1, S2] { type Out = O }
-    implicit def evidence0[S2]: Aux[HNil, S2, S2] = new SetUnion[HNil, S2] { type Out = S2 }
-    implicit def evidence1[H, T <: HList, S2, T2, O](implicit
-        ih: SetInsert.Aux[H, S2, T2],
-        rc: Aux[T, T2, O]): Aux[H :: T, S2, O] =
-      new SetUnion[H :: T, S2] { type Out = O }
-  }
-
-  trait UnitClosure[U] {
-    type Out
-  }
-  object UnitClosure {
-    type Aux[U, O] = UnitClosure[U] { type Out = O }
-
-    implicit def evidenceUnitless: Aux[Unitless, Unitless :: HNil] =
-      new UnitClosure[Unitless] { type Out = Unitless :: HNil }
-
-    implicit def evidenceBase[U](implicit bu: BaseUnit[U]): Aux[U, U :: HNil] =
-      new UnitClosure[U] { type Out = U :: HNil }
-
-    implicit def evidenceDerivedUnit[U, D, DC <: HList](implicit
-        du: DerivedUnit[U, D],
-        dc: Aux[D, DC]): Aux[U, U :: DC] = {
-      new UnitClosure[U] { type Out = U :: DC }
-    }
-
-    implicit def evidenceMul[L, LC, R, RC, OC](implicit
-        l: Aux[L, LC],
-        r: Aux[R, RC],
-        u: SetUnion.Aux[LC, RC, OC]): Aux[%*[L, R], OC] = {
-      new UnitClosure[%*[L, R]] { type Out = OC }
-    }
-
-    implicit def evidenceDiv[L, LC, R, RC, OC](implicit
-        l: Aux[L, LC],
-        r: Aux[R, RC],
-        u: SetUnion.Aux[LC, RC, OC]): Aux[%/[L, R], OC] = {
-      new UnitClosure[%/[L, R]] { type Out = OC }
-    }
-
-    implicit def evidencePow[B, BC, E](implicit
-        b: Aux[B, BC],
-        e: XIntValue[E]): Aux[%^[B, E], BC] = {
-      new UnitClosure[%^[B, E]] {
-        type Out = BC
-      }
-    }
-
-    implicit def evidenceHNil: Aux[HNil, HNil] =
-      new UnitClosure[HNil] { type Out = HNil }
-
-    implicit def evidenceHList[H, T <: HList, HC, TC, OC](implicit
-        h: Aux[H, HC],
-        t: Aux[T, TC],
-        u: SetUnion.Aux[HC, TC, OC]): Aux[H :: T, OC] = {
-      new UnitClosure[H :: T] { type Out = OC }
-    }
   }
 
   trait FilterPrefixUnits[S] {
@@ -194,26 +117,20 @@ private [coulomb] object infra {
     }
   }
 
-  case class UnitDefCode[U](name: String, tpe: String, tpeFull: String, defCode: String)
+  case class UnitDefCode[U](name: String, tpeFull: String)
   object UnitDefCode {
     implicit def evidenceBase[U](implicit utt: TypeTag[U], bu: BaseUnit[U]): UnitDefCode[U] = {
-      val tpe = utt.tpe.typeSymbol.name
       val tpeFull = utt.tpe.typeSymbol.fullName
       UnitDefCode[U](
         bu.name,
-        tpe.toString,
-        tpeFull.toString,
-        s"""implicit val qpDefineUnit$tpe = new BaseUnit[$tpeFull]("${bu.name}", "${bu.abbv}")""")
+        tpeFull.toString)
     }
 
-    implicit def evidenceDerived[U, D](implicit utt: TypeTag[U], du: DerivedUnit[U, D], uts: UnitTypeString[D]): UnitDefCode[U] = {
-      val tpe = utt.tpe.typeSymbol.name
+    implicit def evidenceDerived[U](implicit utt: TypeTag[U], du: DerivedUnit[U, _]): UnitDefCode[U] = {
       val tpeFull = utt.tpe.typeSymbol.fullName
       UnitDefCode[U](
         du.name,
-        tpe.toString,
-        tpeFull.toString,
-        s"""implicit val qpDefineUnit$tpe = new DerivedUnit[$tpeFull, ${uts.expr}](Rational("${du.coef}"), "${du.name}", "${du.abbv}")""")
+        tpeFull.toString)
     }
   }
 
@@ -224,7 +141,7 @@ private [coulomb] object infra {
       UnitDefs[U :: T](c :: t.codes)
   }
 
-  case class QPP[S](unames: Seq[String], pfnames: Seq[String], decls: Seq[String], nameToType: Map[String, String])
+  case class QPP[S](unames: Seq[String], pfnames: Seq[String], nameToType: Map[String, String])
   object QPP {
     implicit def evidence0[S, SU, SPU](implicit
         units: FilterNonPrefixUnits.Aux[S, SU],
@@ -233,7 +150,7 @@ private [coulomb] object infra {
         pfdefs: UnitDefs[SPU]): QPP[S] = {
       val alldefs = udefs.codes ++ pfdefs.codes
       val nameToType = Map(alldefs.map { u => (u.name, u.tpeFull) } :_*)
-      QPP[S](udefs.codes.map(_.name), pfdefs.codes.map(_.name), alldefs.map(_.defCode), nameToType)
+      QPP[S](udefs.codes.map(_.name), pfdefs.codes.map(_.name), nameToType)
     }
   }
 }

--- a/coulomb-parser/src/main/scala/coulomb/parser/parsing.scala
+++ b/coulomb-parser/src/main/scala/coulomb/parser/parsing.scala
@@ -94,11 +94,11 @@ object lexer {
 object ast {
   sealed trait UnitAST {
     override def toString = this match {
-      case Quant(v, u) => s"(Rational($v)).withUnit[$u]"
+      case Quant(v, u) => s"coulomb.Quantity[spire.math.Rational, $u](spire.math.Rational($v))"
       case Unit(u) => u
-      case Mul(lhs, rhs) => s"%*[$lhs, $rhs]"
-      case Div(num, den) => s"%/[$num, $den]"
-      case Pow(rad, exp) => s"%^[$rad, $exp]"
+      case Mul(lhs, rhs) => s"coulomb.%*[$lhs, $rhs]"
+      case Div(num, den) => s"coulomb.%/[$num, $den]"
+      case Pow(rad, exp) => s"coulomb.%^[$rad, $exp]"
     }
   }
   case class Quant(v: Double, u: String) extends UnitAST


### PR DESCRIPTION
I had been working under the (wrong) impression that coulomb stuff needed to be imported inside
the expression that was being runtime compiled, but it seems to be working without that, so I
am getting rid of it.

This might mean the imports need to be in effect at the time of parser creation.
Or possibly only at parse invocation time? I don't understand scala's compilation universes
very well.