### PR TITLE
oraclejdk8 is failing in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ scala:
   - 2.13.0
 
 jdk:
-  - oraclejdk9
+  - oraclejdk8
 
 sudo: false
+
+dist: trusty
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
   - 2.13.0
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 sudo: false
 


### PR DESCRIPTION
travis started failing with jdk8, the internets suggest it is no longer supported