### PR TITLE
only depend on pureconfig modules actually needed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,8 @@ lazy val coulomb_avro = (project in file("coulomb-avro"))
   .settings(libraryDependencies ++= coulombAvroDeps)
 
 def coulombPureConfigDeps = Seq(
-  "com.github.pureconfig" %% "pureconfig" % "0.12.3" % Provided
+  "com.github.pureconfig" %% "pureconfig-core" % "0.12.3" % Provided,
+  "com.github.pureconfig" %% "pureconfig-generic" % "0.12.3" % Provided
 )
 
 lazy val coulomb_pureconfig = (project in file("coulomb-pureconfig"))


### PR DESCRIPTION
no pressure to accept this. I don't really know anything about
pureconfig.  I just happened to notice this in the process of adding
coulomb to the community build