### PR TITLE
quantity parsing uses GetBaseUnit for undeclared support

### DIFF
--- a/coulomb-parser/src/main/scala/coulomb/parser/infra.scala
+++ b/coulomb-parser/src/main/scala/coulomb/parser/infra.scala
@@ -33,7 +33,7 @@ object unitops {
     implicit def evidenceUnitless: UnitTypeString[Unitless] =
       new UnitTypeString[Unitless] { val expr = "coulomb.Unitless" }
 
-    implicit def evidenceBase[U](implicit utt: WeakTypeTag[U], bu: BaseUnit[U]): UnitTypeString[U] =
+    implicit def evidenceBase[U](implicit utt: WeakTypeTag[U], bu: GetBaseUnit[U]): UnitTypeString[U] =
       new UnitTypeString[U] { val expr = utt.tpe.typeSymbol.fullName }
 
     implicit def evidenceDerived[U](implicit utt: WeakTypeTag[U], du: DerivedUnit[U, _]): UnitTypeString[U] =
@@ -91,7 +91,7 @@ object infra {
       new FilterNonPrefixUnits[U :: T] { type Out = U :: TF }
     }
     implicit def evidence2[U, T <: HList, TF <: HList](implicit
-        pfu: BaseUnit[U],
+        pfu: GetBaseUnit[U],
         tf: Aux[T, TF]): Aux[U :: T, U :: TF] = {
       new FilterNonPrefixUnits[U :: T] { type Out = U :: TF }
     }
@@ -99,10 +99,10 @@ object infra {
 
   case class UnitDefCode[U](name: String, tpeFull: String)
   object UnitDefCode {
-    implicit def evidenceBase[U](implicit utt: WeakTypeTag[U], bu: BaseUnit[U]): UnitDefCode[U] = {
+    implicit def evidenceBase[U](implicit utt: WeakTypeTag[U], bu: GetBaseUnit[U]): UnitDefCode[U] = {
       val tpeFull = utt.tpe.typeSymbol.fullName
       UnitDefCode[U](
-        bu.name,
+        bu.bu.name,
         tpeFull.toString)
     }
 

--- a/coulomb-parser/src/main/scala/coulomb/parser/infra.scala
+++ b/coulomb-parser/src/main/scala/coulomb/parser/infra.scala
@@ -52,27 +52,7 @@ object unitops {
 
 object infra {
   import coulomb.parser.unitops._
-
-  trait Evidence[T] {
-    type Out
-  }
-  trait EvidenceLowPriority {
-    type Aux[T, O] = Evidence[T] { type Out = O }
-    implicit def evidenceFalse[T]: Aux[T, false] =
-      new Evidence[T] { type Out = false }
-  }
-  object Evidence extends EvidenceLowPriority {
-    implicit def evidenceTrue[T](implicit t: T): Aux[T, true] =
-      new Evidence[T] { type Out = true }
-  }
-
-  trait NoEvidence[T]
-  object NoEvidence {
-    // Note: if you try to directly ask for Evidence.Aux[T, false], it will match the
-    // low-priority rule above, and this won't work right.
-    implicit def evidence0[T, V](implicit no: Evidence.Aux[T, V], vf: V =:= false): NoEvidence[T] =
-      new NoEvidence[T] {}
-  }
+  import coulomb.infra.NoImplicit
 
   trait FilterPrefixUnits[S] {
     type Out
@@ -86,7 +66,7 @@ object infra {
       new FilterPrefixUnits[U :: T] { type Out = U :: TF }
     }
     implicit def evidence2[U, T <: HList, TF <: HList](implicit
-        npfu: NoEvidence[DerivedUnit[U, Unitless]],
+        npfu: NoImplicit[DerivedUnit[U, Unitless]],
         tf: Aux[T, TF]): Aux[U :: T, TF] = {
       new FilterPrefixUnits[U :: T] { type Out = TF }
     }
@@ -106,7 +86,7 @@ object infra {
     implicit def evidence0: Aux[HNil, HNil] = new FilterNonPrefixUnits[HNil] { type Out = HNil }
     implicit def evidence1[U, T <: HList, TF <: HList](implicit
         pfu: DerivedUnit[U, _],
-        npfu: NoEvidence[DerivedUnit[U, Unitless]],
+        npfu: NoImplicit[DerivedUnit[U, Unitless]],
         tf: Aux[T, TF]): Aux[U :: T, U :: TF] = {
       new FilterNonPrefixUnits[U :: T] { type Out = U :: TF }
     }


### PR DESCRIPTION
forgot to use GetBaseUnit in quantity parsing.
Fixing this allows things like pureconfig i/o on undeclared units.