### PR TITLE
Use Typeable instead of reflect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.bloop/
+.hydra/
+.metals/

--- a/coulomb/src/main/scala/coulomb/define/define.scala
+++ b/coulomb/src/main/scala/coulomb/define/define.scala
@@ -17,7 +17,6 @@ limitations under the License.
 package coulomb.define
 
 import scala.language.implicitConversions
-import scala.reflect.runtime.universe._
 
 import spire.math._
 import shapeless._
@@ -58,8 +57,8 @@ object BaseUnit {
    * @param name the full name of the unit, e.g. "meter"
    * @param abbv an abbreviation for the unit, e.g. "m"
    */
-  def apply[U](name: String = "", abbv: String = "")(implicit ut: WeakTypeTag[U]): BaseUnit[U] = {
-    val n = if (name != "") name else ut.tpe.typeSymbol.name.toString.toLowerCase
+  def apply[U](name: String = "", abbv: String = "")(implicit ut: Typeable[U]): BaseUnit[U] = {
+    val n = if (name != "") name else ut.describe.toLowerCase()
     val a = if (abbv != "") abbv else n.take(1)
     new BaseUnit[U](n, a)
   }
@@ -90,9 +89,9 @@ object DerivedUnit {
    * @param abbv an abbreviation for the unit, e.g. "l"
    */
   def apply[U, D](coef: Rational = Rational(1), name: String = "", abbv: String = "")(implicit
-      ut: WeakTypeTag[U]): DerivedUnit[U, D] = {
+      ut: Typeable[U]): DerivedUnit[U, D] = {
     require(coef > 0, "Unit coefficients must be strictly > 0")
-    val n = if (name != "") name else ut.tpe.typeSymbol.name.toString.toLowerCase
+    val n = if (name != "") name else ut.describe.toLowerCase()
     val a = if (abbv != "") abbv else n.take(1)
     new DerivedUnit[U, D](coef, n, a)
   }
@@ -108,6 +107,6 @@ object PrefixUnit {
    * @param abbv an abbreviation for the unit, e.g. "k"
    */
   def apply[U](coef: Rational = Rational(1), name: String = "", abbv: String = "")(implicit
-      ut: WeakTypeTag[U]): DerivedUnit[U, Unitless] =
+      ut: Typeable[U]): DerivedUnit[U, Unitless] =
     DerivedUnit[U, Unitless](coef, name, abbv)
 }

--- a/coulomb/src/main/scala/coulomb/infra/canonical.scala
+++ b/coulomb/src/main/scala/coulomb/infra/canonical.scala
@@ -47,21 +47,7 @@ object NoImplicit {
 }
 
 object TypeString {
-  import scala.reflect.runtime.universe._
-  def typeString[T :WeakTypeTag]: String = {
-    def work(t: Type): String = {
-      t match { case TypeRef(pre, sym, args) =>
-        val ss = sym.toString
-                    .stripPrefix("free ")
-                    .stripPrefix("trait ")
-                    .stripPrefix("class ")
-                    .stripPrefix("type ")
-        val as = args.map(work)
-        if (args.length <= 0) ss else (ss + "[" + as.mkString(",") + "]")
-      }
-    }
-    work(weakTypeOf[T])
-  }
+  def typeString[T :Typeable]: String = Typeable[T].describe
 }
 
 trait IsUnitExpr[T] {
@@ -91,13 +77,12 @@ trait GetBaseUnit[U] {
   def bu: BaseUnit[U]
 }
 trait GetBaseUnitP1 {
-  import scala.reflect.runtime.universe._
 
   implicit def undeclared[T, TUE](implicit
       enabled: coulomb.policy.EnableUndeclaredBaseUnits,
       testUE: IsUnitExpr.Aux[T, TUE],
       notUE: TUE =:!= true,
-      tt: WeakTypeTag[T]): GetBaseUnit[T] = {
+      tt: Typeable[T]): GetBaseUnit[T] = {
     val name = TypeString.typeString[T]
     new GetBaseUnit[T] {
       val bu = new BaseUnit[T](name, name)

--- a/coulomb/src/main/scala/coulomb/offset/define/define.scala
+++ b/coulomb/src/main/scala/coulomb/offset/define/define.scala
@@ -16,11 +16,10 @@ limitations under the License.
 
 package coulomb.offset.define
 
-import scala.reflect.runtime.universe.WeakTypeTag
-
 import spire.math._
 
 import coulomb.define._
+import shapeless.Typeable
 
 /**
  * An offset unit extends derived unit, with an offset as well as a coefficient
@@ -48,9 +47,9 @@ object OffsetUnit {
    * @param abbv an abbreviation for the offset unit, e.g. "C"
    */
   def apply[U, D](coef: Rational = Rational(1), off: Rational = Rational(0), name: String = "", abbv: String = "")(implicit
-      ut: WeakTypeTag[U]): OffsetUnit[U, D] = {
+      ut: Typeable[U]): OffsetUnit[U, D] = {
     require(coef > 0, "Unit coefficients must be strictly > 0")
-    val n = if (name != "") name else ut.tpe.typeSymbol.name.toString.toLowerCase
+    val n = if (name != "") name else ut.describe
     val a = if (abbv != "") abbv else n.take(1)
     new OffsetUnit[U, D](coef, off, n, a)
   }


### PR DESCRIPTION
This PR is mostly to open a discussion as I'm not totally sure it is the correct solution.

To enable scala.js we need to remove the use of `scala.reflect`. This PR replaces this by shapeless' `Typeable`. This PR runs all the tests correctly and I tested this on scala.js and it works fine