### PR TITLE
More cats instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ def commonSettings = Seq(
   scalaVersion := "2.13.3",
   crossScalaVersions := Seq("2.13.3"),
   licenses += ("Apache-2.0", url("http://opensource.org/licenses/Apache-2.0")),
+  addCompilerPlugin("org.typelevel" % "kind-projector_2.13.3" % "0.11.0"),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots")

--- a/coulomb-tests/src/test/scala/coulomb/cats/CatsSpec.scala
+++ b/coulomb-tests/src/test/scala/coulomb/cats/CatsSpec.scala
@@ -4,6 +4,7 @@ import cats.tests.CatsSuite
 import cats._
 import cats.implicits._
 import cats.kernel.laws.discipline._
+import cats.laws.discipline._
 import cats.data.NonEmptyList
 import coulomb._
 import coulomb.cats.implicits._
@@ -47,4 +48,8 @@ final class CatsSpec extends CatsSuite {
 
   checkAll("EqTest", EqTests[Quantity[Int, MetersPerSecond]].eqv)
   checkAll("OrderTest", OrderTests[Quantity[Int, MetersPerSecond]].order)
+  checkAll("FunctorTest", FunctorTests[Quantity[*, MetersPerSecond]].functor[Int, Double, Int])
+  checkAll("TraverseTest", TraverseTests[Quantity[*, KilometersPerSecond]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("CommutativeMonadTest", CommutativeMonadTests[Quantity[*, KilometersPerSecond]].commutativeMonad[Int, Int, Int])
+  checkAll("MonoidTest", MonoidTests[Quantity[Double, KilometersPerSecond]].monoid)
 }


### PR DESCRIPTION
This PR adds more instances of cats' typeclasses, including `CommutativeMonad`, `Traverse` and `Monoid` and their parent clases, meaning we get `Monad`, `Applicative`, `Functor`, etc