### PR TITLE
move unit declaration parameters into types

### DIFF
--- a/core/src/main/scala/coulomb/define/define.scala
+++ b/core/src/main/scala/coulomb/define/define.scala
@@ -16,10 +16,34 @@
 
 package coulomb.define
 
+/**
+ * @tparam Name unit name
+ * @tparam Abbv unit abbreviation
+ */
 abstract class NamedUnit[Name, Abbv]
 
+/**
+ * @tparam U unit type
+ * @tparam Name unit name
+ * @tparam Abbv unit abbreviation
+ */
 abstract class BaseUnit[U, Name, Abbv] extends NamedUnit[Name, Abbv]
 
+/**
+ * @tparam U unit type
+ * @tparam D unit it is derived from
+ * @tparam Coef unit coefficient, relative to `D`
+ * @tparam Name unit name
+ * @tparam Abbv unit abbreviation
+ */
 abstract class DerivedUnit[U, D, Coef, Name, Abbv] extends NamedUnit[Name, Abbv]
 
+/**
+ * Prefixed units are derived from `1` (the identity unit)
+ * 
+ * @tparam U unit type
+ * @tparam Coef unit coefficient
+ * @tparam Name unit name
+ * @tparam Abbv unit abbreviation
+ */
 abstract class PrefixUnit[U, Coef, Name, Abbv] extends DerivedUnit[U, 1, Coef, Name, Abbv]

--- a/core/src/main/scala/coulomb/define/define.scala
+++ b/core/src/main/scala/coulomb/define/define.scala
@@ -16,29 +16,10 @@
 
 package coulomb.define
 
-import scala.language.implicitConversions
+abstract class NamedUnit[Name, Abbv]
 
-import coulomb.rational.Rational
+abstract class BaseUnit[U, Name, Abbv] extends NamedUnit[Name, Abbv]
 
-/** Methods and values common to all unit and temperature definitions */
-abstract class NamedUnit:
-    /** the full name of a unit, e.g. "meter" */
-    val name: String
-    /** the abbreviation of a unit, e.g. "m" for "meter" */
-    val abbv: String
+abstract class DerivedUnit[U, D, Coef, Name, Abbv] extends NamedUnit[Name, Abbv]
 
-abstract class BaseUnit[U] extends NamedUnit:
-    import coulomb.infra.*
-    override def toString = s"BaseUnit($name, $abbv)"
-
-abstract class DerivedUnit[U, D] extends NamedUnit:
-    import coulomb.infra.*
-    val coef: Rational
-    override def toString = s"DerivedUnit($coef, $name, $abbv)"
-
-// Not necessary, but allows meta-programming to be smarter with coefficients
-abstract class DerivedUnit1[U, D] extends DerivedUnit[U, D]:
-    val coef: Rational = Rational.const1
-
-// prefix units are derived units of 1 ('unitless')
-abstract class PrefixUnit[U] extends DerivedUnit[U, 1]
+abstract class PrefixUnit[U, Coef, Name, Abbv] extends DerivedUnit[U, 1, Coef, Name, Abbv]

--- a/core/src/main/scala/coulomb/infra/meta.scala
+++ b/core/src/main/scala/coulomb/infra/meta.scala
@@ -75,26 +75,28 @@ object meta:
     // Coefficient[U1, U2]
     def coefficient[U1, U2](using Quotes, Type[U1], Type[U2]): Expr[Coefficient[U1, U2]] =
         import quotes.reflect.*
-        val rcoef = coef(TypeRepr.of[U1], TypeRepr.of[U2])
-        '{ new Coefficient[U1, U2] { val value = $rcoef } }
+        // this call will fail if no coefficient exists, which means that
+        // U1 and U2 are not convertable
+        val c = coef(TypeRepr.of[U1], TypeRepr.of[U2])
+        '{ new Coefficient[U1, U2] { val value = ${Expr(c)} } }
 
-    def coef(using Quotes)(u1: quotes.reflect.TypeRepr, u2: quotes.reflect.TypeRepr): Expr[Rational] =
+    def coef(using Quotes)(u1: quotes.reflect.TypeRepr, u2: quotes.reflect.TypeRepr): Rational =
         import quotes.reflect.*
         if (u1 =:= u2) then
             // confirm that the type has a defined canonical signature, or fail
             val _ = cansig(u1)
             // the coefficient between two identical unit expression types is always exactly 1
-            '{ Rational.const1 }
+            Rational.const1
         // the fundamental algorithmic unit analysis criterion:
         // http://erikerlandson.github.io/blog/2019/05/03/algorithmic-unit-analysis/
         val (rcoef, rsig) = cansig(TypeRepr.of[/].appliedTo(List(u1, u2)))
         if (rsig =:= TypeRepr.of[SNil]) then rcoef else
             report.error(s"units are not convertable: ($u1) ($u2)")
-            '{ Rational.const0 }
+            Rational.const0
 
     // returns tuple: (expr-for-coef, type-of-Res)
-    def cansig(using Quotes)(u: quotes.reflect.TypeRepr, top: Boolean = false):
-            (Expr[Rational], quotes.reflect.TypeRepr) =
+    def cansig(using Quotes)(u: quotes.reflect.TypeRepr):
+            (Rational, quotes.reflect.TypeRepr) =
         import quotes.reflect.*
         // if this encounters a unit type pattern it cannot expand to a canonical signature,
         // at any level, it raises a compile-time error such that the context parameter search fails.
@@ -105,36 +107,32 @@ object meta:
             case AppliedType(op, List(lu, ru)) if (op =:= TypeRepr.of[*]) =>
                 val (lcoef, lsig) = cansig(lu)
                 val (rcoef, rsig) = cansig(ru)
-                val ucoef = if (coefIs1(lcoef)) rcoef else if (coefIs1(rcoef)) lcoef else '{ $lcoef * $rcoef }
                 val usig = unifyOp(lsig, rsig, _ + _)
-                (ucoef, usig)
+                (lcoef * rcoef, usig)
             case AppliedType(op, List(lu, ru)) if (op =:= TypeRepr.of[/]) =>
                 val (lcoef, lsig) = cansig(lu)
                 val (rcoef, rsig) = cansig(ru)
-                val ucoef = if (coefIs1(rcoef)) lcoef else '{ $lcoef / $rcoef }
                 val usig = unifyOp(lsig, rsig, _ - _)
-                (ucoef, usig)
+                (lcoef / rcoef, usig)
             case AppliedType(op, List(b, p)) if (op =:= TypeRepr.of[^]) =>
                 val (bcoef, bsig) = cansig(b)
                 val ratexp(e) = p
-                if (e == 0) ('{ Rational.const1 }, signil())
+                if (e == 0) (Rational.const1, signil())
                 else if (e == 1) (bcoef, bsig)
                 else
-                    val ucoef = if (coefIs1(bcoef)) bcoef
-                                else if (e.d == 1) '{ ${bcoef}.pow(${Expr(e.n.toInt)}) }
-                                else '{ ${bcoef}.pow(${Expr(e.n.toInt)}).root(${Expr(e.d.toInt)}) }
+                    val ucoef = if (e.d == 1) bcoef.pow(e.n.toInt)
+                                else bcoef.pow(e.n.toInt).root(e.d.toInt)
                     val usig = unifyPow(p, bsig)
                     (ucoef, usig)
-            case unitless() => ('{ Rational.const1 }, signil())
-            case unitconst(c) => ('{ Rational(${Expr(c.n)}, ${Expr(c.d)}) }, signil())
-            case baseunit() => ('{ Rational.const1 }, sigcons(u, Rational.const1, signil()))
-            case derivedunit1(ucoef, usig) => (ucoef, usig)
+            case unitless() => (Rational.const1, signil())
+            case unitconst(c) => (c, signil())
+            case baseunit() => (Rational.const1, sigcons(u, Rational.const1, signil()))
             case derivedunit(ucoef, usig) => (ucoef, usig)
             case _ if (!strictunitexprs) =>
                 // we consider any other type for "promotion" to base-unit only if
                 // it does not match the strict unit expression forms above, and
                 // if the strict unit expression policy has not been enabled
-                ('{ Rational.const1 }, sigcons(u, Rational.const1, signil()))
+                (Rational.const1, sigcons(u, Rational.const1, signil()))
             case _ => { report.error(s"unknown unit expression in cansig: $u"); csErr }
 
     def stdsig(using Quotes)(u: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr =
@@ -157,7 +155,6 @@ object meta:
             case unitless() => signil()
             case unitconst(c) => sigcons(ratexp(c), Rational.const1, signil())
             case baseunit() => sigcons(u, Rational.const1, signil())
-            case derivedunit1(_, _) => sigcons(u, Rational.const1, signil())
             case derivedunit(_, _) => sigcons(u, Rational.const1, signil())
             case _ if (!strictunitexprs) =>
                 // we consider any other type for "promotion" to base-unit only if
@@ -242,40 +239,23 @@ object meta:
     object baseunit:
         def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
             import quotes.reflect.*
-            Implicits.search(TypeRepr.of[BaseUnit].appliedTo(u)) match
+            Implicits.search(TypeRepr.of[BaseUnit].appliedTo(List(u, TypeBounds.empty, TypeBounds.empty))) match
                 case iss: ImplicitSearchSuccess => true
                 case _ => false
 
-    object derivedunit1:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[(Expr[Rational], quotes.reflect.TypeRepr)] =
-            import quotes.reflect.*
-            Implicits.search(TypeRepr.of[DerivedUnit1].appliedTo(List(u, TypeBounds.empty))) match
-                case iss: ImplicitSearchSuccess =>
-                    val AppliedType(_, List(_, d)) = iss.tree.tpe.baseType(TypeRepr.of[DerivedUnit1].typeSymbol)
-                    val (dcoef, dsig) = cansig(d)
-                    // in the DerivedUnit1 special case, coef=1 by definition, so we can propagate dcoef directly
-                    Some((dcoef, dsig))
-                case _ => None
-
     object derivedunit:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[(Expr[Rational], quotes.reflect.TypeRepr)] =
+        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[(Rational, quotes.reflect.TypeRepr)] =
             import quotes.reflect.*
-            Implicits.search(TypeRepr.of[DerivedUnit].appliedTo(List(u, TypeBounds.empty))) match
+            Implicits.search(TypeRepr.of[DerivedUnit].appliedTo(List(u, TypeBounds.empty, TypeBounds.empty, TypeBounds.empty, TypeBounds.empty))) match
                 case iss: ImplicitSearchSuccess =>
-                    val AppliedType(_, List(_, d)) = iss.tree.tpe.baseType(TypeRepr.of[DerivedUnit].typeSymbol)
+                    val AppliedType(_, List(_, d, c, _, _)) = iss.tree.tpe.baseType(TypeRepr.of[DerivedUnit].typeSymbol)
+                    val rationalTE(coef) = c
                     val (dcoef, dsig) = cansig(d)
-                    val du = iss.tree.asExpr.asInstanceOf[Expr[DerivedUnit[?, ?]]]
-                    val ucoef = if (coefIs1(dcoef)) '{ ${du}.coef } else '{ $dcoef * ${du}.coef }
-                    Some((ucoef, dsig))
+                    Some((coef * dcoef, dsig))
                 case _ => None
 
-    // evaluating these at compilation time is not working, so the best I currently
-    // know how to do is structural test for Rational.const1
-    def coefIs1(using Quotes)(expr: Expr[Rational]): Boolean =
-        expr.matches('{ Rational.const1 })
-
-    def csErr(using Quotes): (Expr[Rational], quotes.reflect.TypeRepr) =
-        ('{ Rational.const0 }, quotes.reflect.TypeRepr.of[Nothing])
+    def csErr(using Quotes): (Rational, quotes.reflect.TypeRepr) =
+        (Rational.const0, quotes.reflect.TypeRepr.of[Nothing])
 
     // keep this for reference
     def summonString[T](using Quotes, Type[T]): String =
@@ -411,7 +391,7 @@ object meta:
         def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
             u =:= quotes.reflect.TypeRepr.of[String]
 
-    def typestr(using Quotes)(t: quotes.reflect.TypeRepr): Expr[String] =
+    def typestr(using Quotes)(t: quotes.reflect.TypeRepr): String =
         import quotes.reflect.*
         def work(tr: TypeRepr): String = tr match
             case AppliedType(tc, ta) =>
@@ -421,4 +401,4 @@ object meta:
                     tcn + "[" + as.mkString(",") + "]"
             case t => t.typeSymbol.name
         val ts = work(t.dealias)
-        Expr(ts)
+        ts

--- a/core/src/main/scala/coulomb/ops/show/show.scala
+++ b/core/src/main/scala/coulomb/ops/show/show.scala
@@ -42,15 +42,25 @@ object meta:
 
     def showStandard[U](using Quotes, Type[U]): Expr[Show[U]] =
         import quotes.reflect.*
-        val usexpr = showrender(TypeRepr.of[U], (nu: Expr[NamedUnit]) => '{ ${nu}.abbv })
-        '{ new Show[U] { val value = $usexpr } }
+        val render = (tr: TypeRepr) => {
+            val AppliedType(_, List(_, a)) = tr
+            val strlt(abbv) = a
+            abbv
+        }
+        val usexpr = showrender(TypeRepr.of[U], render)
+        '{ new Show[U] { val value = ${Expr(usexpr)} } }
 
     def showFullStandard[U](using Quotes, Type[U]): Expr[ShowFull[U]] =
         import quotes.reflect.*
-        val usexpr = showrender(TypeRepr.of[U], (nu: Expr[NamedUnit]) => '{ ${nu}.name })
-        '{ new ShowFull[U] { val value = $usexpr } }
+        val render = (tr: TypeRepr) => {
+            val AppliedType(_, List(n, _)) = tr
+            val strlt(name) = n
+            name
+        }
+        val usexpr = showrender(TypeRepr.of[U], render)
+        '{ new ShowFull[U] { val value = ${Expr(usexpr)} } }
 
-    def showrender(using Quotes)(u: quotes.reflect.TypeRepr, render: Expr[NamedUnit] => Expr[String]): Expr[String] =
+    def showrender(using Quotes)(u: quotes.reflect.TypeRepr, render: quotes.reflect.TypeRepr => String): String =
         import quotes.reflect.*
         u match
             case flatmul(t) => termstr(t, render)
@@ -58,19 +68,19 @@ object meta:
                 showrender(lu, render)
             case AppliedType(op, List(lu, ru)) if (op =:= TypeRepr.of[/]) =>
                 val (ls, rs) = (paren(lu, render), paren(ru, render))
-                '{ ${ls} + "/" + ${rs} }
+                s"${ls}/${rs}"
             case AppliedType(op, List(b, e)) if (op =:= TypeRepr.of[^]) =>
                 val (bs, es) = (paren(b, render), powstr(e))
-                '{ ${bs} + "^" + ${es} }
+                s"${bs}^${es}"
             case unitconst(v) =>
-                if (v.d == 1) Expr(v.n.toString) else '{ "(" + ${Expr(v.n.toString)} + "/" + ${Expr(v.d.toString)} + ")" }
+                if (v.d == 1) v.n.toString else s"(${v.n.toString}/${v.d.toString})"
             case namedunit(nu) => render(nu)
             case _ if (!strictunitexprs) => typestr(u)
             case _ =>
                 report.error(s"unrecognized unit pattern $u")
-                '{ "" }
+                ""
 
-    def termstr(using Quotes)(terms: List[quotes.reflect.TypeRepr], render: Expr[NamedUnit] => Expr[String]): Expr[String] =
+    def termstr(using Quotes)(terms: List[quotes.reflect.TypeRepr], render: quotes.reflect.TypeRepr => String): String =
         import quotes.reflect.*
         // values for terms constructed from 'flatmul' should have >= 2 terms to start
         // so should terms should never be empty in this recursion
@@ -81,11 +91,11 @@ object meta:
                 val t = termstr(tail, render)
                 // tail should never be empty (see above)
                 term match
-                    case namedPU(_) => '{ ${h} + ${t} }
-                    case _ => '{ ${h} + " " + ${t} }
+                    case namedPU(_) => s"${h}${t}"
+                    case _ => s"${h} ${t}"
             case _ =>
                 report.error(s"unrecognized termstr pattern $terms")
-                '{ "" }
+                ""
 
     object flatmul:
         def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[List[quotes.reflect.TypeRepr]] =
@@ -101,17 +111,17 @@ object meta:
                     Some(lflat ++ rflat)
                 case _ => None
 
-    def powstr(using Quotes)(p: quotes.reflect.TypeRepr): Expr[String] =
+    def powstr(using Quotes)(p: quotes.reflect.TypeRepr): String =
         import quotes.reflect.*
         p match
-            case intlt(n) if (n >= 0) => Expr(n.toString)
-            case intlt(n) if (n < 0) => '{ "(" + ${Expr(n.toString)} + ")" }
-            case ratlt(n, d) => '{ "(" + ${Expr(n.toString)} + "/" + ${Expr(d.toString)} + ")" }
-            case _ => '{ "!!!" }
+            case intlt(n) if (n >= 0) => n.toString
+            case intlt(n) if (n < 0) => s"(${n.toString})"
+            case ratlt(n, d) => s"(${n.toString}/${d.toString})"
+            case _ => "!!!"
 
-    def paren(using Quotes)(u: quotes.reflect.TypeRepr, render: Expr[NamedUnit] => Expr[String]): Expr[String] =
+    def paren(using Quotes)(u: quotes.reflect.TypeRepr, render: quotes.reflect.TypeRepr => String): String =
         val str = showrender(u, render)
-        if (atomic(u)) str else '{ "(" + ${str} + ")" }
+        if (atomic(u)) str else s"(${str})"
 
     def atomic(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
         import quotes.reflect.*
@@ -124,7 +134,7 @@ object meta:
             case _ => false
 
     object namedunit:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[Expr[NamedUnit]] =
+        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[quotes.reflect.TypeRepr] =
             import quotes.reflect.*
             u match
                 case namedBU(nu) => Some(nu)
@@ -132,22 +142,22 @@ object meta:
                 case _ => None
 
     object namedPU:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[Expr[NamedUnit]] =
+        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[quotes.reflect.TypeRepr] =
             import quotes.reflect.*
-            Implicits.search(TypeRepr.of[DerivedUnit].appliedTo(List(u, TypeRepr.of[1]))) match
-                case iss: ImplicitSearchSuccess => Some(iss.tree.asExpr.asInstanceOf[Expr[NamedUnit]])
+            Implicits.search(TypeRepr.of[DerivedUnit].appliedTo(List(u, TypeRepr.of[1], TypeBounds.empty, TypeBounds.empty, TypeBounds.empty))) match
+                case iss: ImplicitSearchSuccess => Some(iss.tree.tpe.baseType(TypeRepr.of[NamedUnit].typeSymbol))
                 case _ => None
 
     object namedBU:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[Expr[NamedUnit]] =
+        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[quotes.reflect.TypeRepr] =
             import quotes.reflect.*
-            Implicits.search(TypeRepr.of[BaseUnit].appliedTo(u)) match
-                case iss: ImplicitSearchSuccess => Some(iss.tree.asExpr.asInstanceOf[Expr[NamedUnit]])
+            Implicits.search(TypeRepr.of[BaseUnit].appliedTo(List(u, TypeBounds.empty, TypeBounds.empty))) match
+                case iss: ImplicitSearchSuccess => Some(iss.tree.tpe.baseType(TypeRepr.of[NamedUnit].typeSymbol))
                 case _ => None
 
     object namedDU:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[Expr[NamedUnit]] =
+        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[quotes.reflect.TypeRepr] =
             import quotes.reflect.*
-            Implicits.search(TypeRepr.of[DerivedUnit].appliedTo(List(u, TypeBounds.empty))) match
-                case iss: ImplicitSearchSuccess => Some(iss.tree.asExpr.asInstanceOf[Expr[NamedUnit]])
+            Implicits.search(TypeRepr.of[DerivedUnit].appliedTo(List(u, TypeBounds.empty, TypeBounds.empty, TypeBounds.empty, TypeBounds.empty))) match
+                case iss: ImplicitSearchSuccess => Some(iss.tree.tpe.baseType(TypeRepr.of[NamedUnit].typeSymbol))
                 case _ => None

--- a/units/src/main/scala/coulomb/units/si/prefixes/prefixes.scala
+++ b/units/src/main/scala/coulomb/units/si/prefixes/prefixes.scala
@@ -17,40 +17,22 @@
 package coulomb.units.si.prefixes
 
 import coulomb.define.*
-import coulomb.rational.Rational
+import coulomb.{`*`, `/`, `^`}
 
 final type Kilo
-given PrefixUnit[Kilo] with
-    val name = "kilo"
-    val abbv = "k"
-    val coef = Rational(1000)
+given ctx_Unit_Kilo: PrefixUnit[Kilo, 10 ^ 3, "kilo", "k"] with {}
 
 final type Mega
-given PrefixUnit[Mega] with
-    val name = "mega"
-    val abbv = "M"
-    val coef = Rational(1000).pow(2)
+given ctx_Unit_Mega: PrefixUnit[Mega, 10 ^ 6, "mega", "M"] with {}
 
 final type Giga
-given PrefixUnit[Giga] with
-    val name = "giga"
-    val abbv = "G"
-    val coef = Rational(1000).pow(3)
+given ctx_Unit_Giga: PrefixUnit[Giga, 10 ^ 9, "giga", "G"] with {}
 
 final type Milli
-given PrefixUnit[Milli] with
-    val name = "milli"
-    val abbv = "m"
-    val coef = Rational(1000).pow(-1)
+given ctx_Unit_Milli: PrefixUnit[Milli, 10 ^ -3, "milli", "m"] with {}
 
 final type Micro
-given PrefixUnit[Micro] with
-    val name = "micro"
-    val abbv = "μ"
-    val coef = Rational(1000).pow(-2)
+given ctx_Unit_Micro: PrefixUnit[Micro, 10 ^ -6, "micro", "μ"] with {}
 
 final type Nano
-given PrefixUnit[Nano] with
-    val name = "nano"
-    val abbv = "n"
-    val coef = Rational(1000).pow(-3)
+given ctx_Unit_Nano: PrefixUnit[Nano, 10 ^ -9, "nano", "n"] with {}

--- a/units/src/main/scala/coulomb/units/si/si.scala
+++ b/units/src/main/scala/coulomb/units/si/si.scala
@@ -17,38 +17,18 @@
 package coulomb.units.si
 
 import coulomb.define.*
+import coulomb.{`*`, `/`, `^`}
 
 final type Meter
-given BaseUnit[Meter] with
-    val name = "meter"
-    val abbv = "m"
+given ctx_Unit_Meter: BaseUnit[Meter, "meter", "m"] with {}
 
 final type Kilogram
-given BaseUnit[Kilogram] with
-    val name = "kilogram"
-    val abbv = "kg"
+given ctx_Unit_Kilogram: BaseUnit[Kilogram, "kilogram", "kg"] with {}
 
 final type Second
-given BaseUnit[Second] with
-    val name = "second"
-    val abbv = "s"
+given ctx_Unit_Second: BaseUnit[Second, "second", "s"] with {}
 
-final type Ampere
-given BaseUnit[Ampere] with
-    val name = "ampere"
-    val abbv = "A"
+final type Minute
+given ctx_Unit_Minute: DerivedUnit[Minute, Second, 60, "minute", "min"] with {}
 
-final type Mole
-given BaseUnit[Mole] with
-    val name = "mole"
-    val abbv = "mol"
 
-final type Candela
-given BaseUnit[Candela] with
-    val name = "candela"
-    val abbv = "cd"
-
-final type Kelvin
-given BaseUnit[Kelvin] with
-    val name = "Kelvin"
-    val abbv = "K"


### PR DESCRIPTION
This significantly simplifies and optimizes the `Expr` objects generated for `Coefficient` and `Show` in the metaprogramming, and also makes some of the metaprogramming logic cleaner.

Unit defs now look like:

```scala
final type Meter
given ctx_Unit_Meter: BaseUnit[Meter, "meter", "m"] with {}

final type Kilo
given ctx_Unit_Kilo: PrefixUnit[Kilo, 10 ^ 3, "kilo", "k"] with {}

final type Minute
given ctx_Unit_Minute: DerivedUnit[Minute, Second, 60, "minute", "min"] with {}
```
