### PR TITLE
Direct coefficient

### DIFF
--- a/core/src/main/scala/coulomb/conversion/standard/implicit/implicit.scala
+++ b/core/src/main/scala/coulomb/conversion/standard/implicit/implicit.scala
@@ -23,7 +23,7 @@ import coulomb.conversion.{ValueConversion, UnitConversion}
 // Quantity[V1, U1] -> Quantity[V2, U2], whenever a valid conversion exists
 // reference:
 // https://docs.scala-lang.org/scala3/reference/contextual/conversions.html
-transparent inline given ctx_implicit_quantity_conversion[VF, UF, VT, UT](using
+inline given ctx_implicit_quantity_conversion[VF, UF, VT, UT](using
     vc: ValueConversion[VF, VT],
     uc: UnitConversion[VT, UF, UT]
         ): scala.Conversion[Quantity[VF, UF], Quantity[VT, UT]] =

--- a/core/src/main/scala/coulomb/conversion/standard/integral/integral.scala
+++ b/core/src/main/scala/coulomb/conversion/standard/integral/integral.scala
@@ -17,8 +17,7 @@
 package coulomb.conversion.standard.integral
 
 import coulomb.conversion.{ValueConversion, UnitConversion, ValueResolution}
-import coulomb.Coefficient
-import coulomb.rational.Rational
+import coulomb.coefficient
 
 given ctx_VC_Double_Long: ValueConversion[Double, Long] with
     def apply(v: Double): Long = v.toLong
@@ -32,19 +31,21 @@ given ctx_VC_Float_Long: ValueConversion[Float, Long] with
 given ctx_VC_Float_Int: ValueConversion[Float, Int] with
     def apply(v: Float): Int = v.toInt
 
-transparent inline given ctx_UC_Long[UF, UT](using coef: Coefficient[UF, UT]):
+transparent inline given ctx_UC_Long[UF, UT]:
         UnitConversion[Long, UF, UT] =
-    val nc = coef.value.n.toDouble
-    val dc = coef.value.d.toDouble
+    val coef = coefficient[UF, UT]
+    val nc = coef.n.toDouble
+    val dc = coef.d.toDouble
     // using nc and dc is more efficient than using Rational directly in the conversion function
     // but still gives us 53 bits of integer precision for exact rational arithmetic, and also
     // graceful loss of precision if nc*v exceeds 53 bits
     new UnitConversion[Long, UF, UT]:
         def apply(v: Long): Long = ((nc * v) / dc).toLong
 
-transparent inline given ctx_UC_Int[UF, UT](using coef: Coefficient[UF, UT]):
+transparent inline given ctx_UC_Int[UF, UT]:
         UnitConversion[Int, UF, UT] =
-    val nc = coef.value.n.toDouble
-    val dc = coef.value.d.toDouble
+    val coef = coefficient[UF, UT]
+    val nc = coef.n.toDouble
+    val dc = coef.d.toDouble
     new UnitConversion[Int, UF, UT]:
         def apply(v: Int): Int = ((nc * v) / dc).toInt

--- a/core/src/main/scala/coulomb/conversion/standard/integral/integral.scala
+++ b/core/src/main/scala/coulomb/conversion/standard/integral/integral.scala
@@ -31,7 +31,7 @@ given ctx_VC_Float_Long: ValueConversion[Float, Long] with
 given ctx_VC_Float_Int: ValueConversion[Float, Int] with
     def apply(v: Float): Int = v.toInt
 
-transparent inline given ctx_UC_Long[UF, UT]:
+inline given ctx_UC_Long[UF, UT]:
         UnitConversion[Long, UF, UT] =
     val coef = coefficient[UF, UT]
     val nc = coef.n.toDouble
@@ -42,7 +42,7 @@ transparent inline given ctx_UC_Long[UF, UT]:
     new UnitConversion[Long, UF, UT]:
         def apply(v: Long): Long = ((nc * v) / dc).toLong
 
-transparent inline given ctx_UC_Int[UF, UT]:
+inline given ctx_UC_Int[UF, UT]:
         UnitConversion[Int, UF, UT] =
     val coef = coefficient[UF, UT]
     val nc = coef.n.toDouble

--- a/core/src/main/scala/coulomb/conversion/standard/standard.scala
+++ b/core/src/main/scala/coulomb/conversion/standard/standard.scala
@@ -17,7 +17,7 @@
 package coulomb.conversion.standard
 
 import coulomb.conversion.{ValueConversion, UnitConversion, ValueResolution}
-import coulomb.Coefficient
+import coulomb.coefficient
 
 // 16 of these - full crossproduct
 transparent inline given ctx_VR_Double_Double: ValueResolution[Double, Double] =
@@ -127,14 +127,14 @@ given ctx_VC_Int_Int: ValueConversion[Int, Int] with
 // 4 of these - one for each of the big 4
 // unit conversions that discard fractional values can be imported from 
 // the 'integral' subpackage
-transparent inline given ctx_UC_Double[UF, UT](using coef: Coefficient[UF, UT]):
+transparent inline given ctx_UC_Double[UF, UT]:
         UnitConversion[Double, UF, UT] =
-    val c = coef.value.toDouble
+    val c = coefficient[UF, UT].toDouble
     new UnitConversion[Double, UF, UT]:
         def apply(v: Double): Double = c * v
 
-transparent inline given ctx_UC_Float[UF, UT](using coef: Coefficient[UF, UT]):
+transparent inline given ctx_UC_Float[UF, UT]:
         UnitConversion[Float, UF, UT] =
-    val c = coef.value.toFloat
+    val c = coefficient[UF, UT].toFloat
     new UnitConversion[Float, UF, UT]:
         def apply(v: Float): Float = c * v

--- a/core/src/main/scala/coulomb/conversion/standard/standard.scala
+++ b/core/src/main/scala/coulomb/conversion/standard/standard.scala
@@ -127,13 +127,13 @@ given ctx_VC_Int_Int: ValueConversion[Int, Int] with
 // 4 of these - one for each of the big 4
 // unit conversions that discard fractional values can be imported from 
 // the 'integral' subpackage
-transparent inline given ctx_UC_Double[UF, UT]:
+inline given ctx_UC_Double[UF, UT]:
         UnitConversion[Double, UF, UT] =
     val c = coefficient[UF, UT].toDouble
     new UnitConversion[Double, UF, UT]:
         def apply(v: Double): Double = c * v
 
-transparent inline given ctx_UC_Float[UF, UT]:
+inline given ctx_UC_Float[UF, UT]:
         UnitConversion[Float, UF, UT] =
     val c = coefficient[UF, UT].toFloat
     new UnitConversion[Float, UF, UT]:

--- a/core/src/main/scala/coulomb/infra/show.scala
+++ b/core/src/main/scala/coulomb/infra/show.scala
@@ -14,51 +14,33 @@
  * limitations under the License.
  */
 
-package coulomb.ops.show
+package coulomb.infra
 
-import scala.annotation.implicitNotFound
-
-@implicitNotFound("Unit string not defined in scope for ${U}")
-abstract class Show[U]:
-    val value: String
-
-object Show:
-  transparent inline given showStandard[U]: Show[U] =
-      ${ meta.showStandard[U] }
-
-@implicitNotFound("Full Unit string not defined in scope for ${U}")
-abstract class ShowFull[U]:
-    val value: String
-
-object ShowFull:
-  transparent inline given showFullStandard[U]: ShowFull[U] =
-      ${ meta.showFullStandard[U] }
-
-object meta:
+object show:
     import scala.quoted.*
     import coulomb.*
     import coulomb.define.*
     import coulomb.infra.meta.*
 
-    def showStandard[U](using Quotes, Type[U]): Expr[Show[U]] =
+    def show[U](using Quotes, Type[U]): Expr[String] =
         import quotes.reflect.*
         val render = (tr: TypeRepr) => {
             val AppliedType(_, List(_, a)) = tr
             val strlt(abbv) = a
             abbv
         }
-        val usexpr = showrender(TypeRepr.of[U], render)
-        '{ new Show[U] { val value = ${Expr(usexpr)} } }
+        val str = showrender(TypeRepr.of[U], render)
+        Expr(str)
 
-    def showFullStandard[U](using Quotes, Type[U]): Expr[ShowFull[U]] =
+    def showFull[U](using Quotes, Type[U]): Expr[String] =
         import quotes.reflect.*
         val render = (tr: TypeRepr) => {
             val AppliedType(_, List(n, _)) = tr
             val strlt(name) = n
             name
         }
-        val usexpr = showrender(TypeRepr.of[U], render)
-        '{ new ShowFull[U] { val value = ${Expr(usexpr)} } }
+        val str = showrender(TypeRepr.of[U], render)
+        Expr(str)
 
     def showrender(using Quotes)(u: quotes.reflect.TypeRepr, render: quotes.reflect.TypeRepr => String): String =
         import quotes.reflect.*

--- a/core/src/main/scala/coulomb/ops/standard/add.scala
+++ b/core/src/main/scala/coulomb/ops/standard/add.scala
@@ -20,7 +20,7 @@ import scala.util.NotGiven
 
 import coulomb.ops.{Add, Sub, Mul, Div, Neg, Pow}
 import coulomb.conversion.{ValueConversion, UnitConversion, ValueResolution}
-import coulomb.Coefficient
+import coulomb.coefficient
 
 // specialize these for efficiency, and as a
 // proof of concept that specializations can operate in this system
@@ -49,20 +49,18 @@ transparent inline given ctx_add_Int_1U[U]: Add[Int, U, Int, U] =
         def apply(vl: Int, vr: Int): Int = vl + vr
 
 transparent inline given ctx_add_Double_2U[UL, UR](using
-    neu: NotGiven[UL =:= UR],
-    coef: Coefficient[UR, UL]
+    neu: NotGiven[UL =:= UR]
         ): Add[Double, UL, Double, UR] =
-    val c = coef.value.toDouble
+    val c = coefficient[UR, UL].toDouble
     new Add[Double, UL, Double, UR]:
         type VO = Double
         type UO = UL
         def apply(vl: Double, vr: Double): Double = vl + (c * vr)
 
 transparent inline given ctx_add_Float_2U[UL, UR](using
-    neu: NotGiven[UL =:= UR],
-    coef: Coefficient[UR, UL]
+    neu: NotGiven[UL =:= UR]
         ): Add[Float, UL, Float, UR] =
-    val c = coef.value.toFloat
+    val c = coefficient[UR, UL].toFloat
     new Add[Float, UL, Float, UR]:
         type VO = Float
         type UO = UL

--- a/core/src/main/scala/coulomb/quantity.scala
+++ b/core/src/main/scala/coulomb/quantity.scala
@@ -78,12 +78,10 @@ object quantity:
 end quantity
 
 import coulomb.ops.*
-import coulomb.ops.show.*
-import scala.annotation.implicitNotFound
 
 extension[VL, UL](ql: Quantity[VL, UL])
-    transparent inline def show(using sh: Show[UL]): String = s"${ql.value.toString} ${sh.value}"
-    transparent inline def showFull(using sh: ShowFull[UL]): String = s"${ql.value.toString} ${sh.value}"
+    inline def show: String = s"${ql.value.toString} ${showUnit[UL]}"
+    inline def showFull: String = s"${ql.value.toString} ${showUnitFull[UL]}"
 
     transparent inline def +[VR, UR](qr: Quantity[VR, UR])(using add: Add[VL, UL, VR, UR]): Quantity[add.VO, add.UO] =
         add(ql.value, qr.value).withUnit[add.UO]
@@ -108,8 +106,8 @@ extension[VL, UL](ql: Quantity[VL, UL])
     transparent inline def toUnit[U](using
         conv: coulomb.conversion.UnitConversion[VL, UL, U]): Quantity[VL, U] = conv(ql.value).withUnit[U]
 
-def showUnit[U](using sh: Show[U]): String = sh.value
-def showUnitFull[U](using sh: ShowFull[U]): String = sh.value
+inline def showUnit[U]: String = ${ coulomb.infra.show.show[U] }
+inline def showUnitFull[U]: String = ${ coulomb.infra.show.showFull[U] }
 
 /** obtain the coefficient */
 inline def coefficient[U1, U2] = ${ coulomb.infra.meta.coefficient[U1, U2] }

--- a/core/src/main/scala/coulomb/quantity.scala
+++ b/core/src/main/scala/coulomb/quantity.scala
@@ -111,11 +111,5 @@ extension[VL, UL](ql: Quantity[VL, UL])
 def showUnit[U](using sh: Show[U]): String = sh.value
 def showUnitFull[U](using sh: ShowFull[U]): String = sh.value
 
-@implicitNotFound("No coefficient of conversion exists for unit types (${U1}) and (${U2})")
-abstract class Coefficient[U1, U2]:
-    val value: coulomb.rational.Rational
-    override def toString = s"Coefficient($value)"
-
-object Coefficient:
-    transparent inline given [U1, U2]: Coefficient[U1, U2] =
-        ${ coulomb.infra.meta.coefficient[U1, U2] }
+/** obtain the coefficient */
+inline def coefficient[U1, U2] = ${ coulomb.infra.meta.coefficient[U1, U2] }

--- a/core/src/main/scala/coulomb/quantity.scala
+++ b/core/src/main/scala/coulomb/quantity.scala
@@ -78,6 +78,7 @@ object quantity:
 end quantity
 
 import coulomb.ops.*
+import coulomb.rational.Rational
 
 extension[VL, UL](ql: Quantity[VL, UL])
     inline def show: String = s"${ql.value.toString} ${showUnit[UL]}"
@@ -109,5 +110,8 @@ extension[VL, UL](ql: Quantity[VL, UL])
 inline def showUnit[U]: String = ${ coulomb.infra.show.show[U] }
 inline def showUnitFull[U]: String = ${ coulomb.infra.show.showFull[U] }
 
-/** obtain the coefficient */
-inline def coefficient[U1, U2] = ${ coulomb.infra.meta.coefficient[U1, U2] }
+/**
+ * Obtain the coefficient of conversion from U1 -> U2
+ * If U1 and U2 are not convertible, causes a compilation failure.
+ */
+inline def coefficient[U1, U2]: Rational = ${ coulomb.infra.meta.coefficient[U1, U2] }

--- a/core/src/main/scala/coulomb/quantity.scala
+++ b/core/src/main/scala/coulomb/quantity.scala
@@ -79,10 +79,25 @@ end quantity
 
 import coulomb.ops.*
 import coulomb.rational.Rational
+import coulomb.conversion.{ValueConversion, UnitConversion}
+
+inline def showUnit[U]: String = ${ coulomb.infra.show.show[U] }
+inline def showUnitFull[U]: String = ${ coulomb.infra.show.showFull[U] }
+
+/**
+ * Obtain the coefficient of conversion from U1 -> U2
+ * If U1 and U2 are not convertible, causes a compilation failure.
+ */
+inline def coefficient[U1, U2]: Rational = ${ coulomb.infra.meta.coefficient[U1, U2] }
 
 extension[VL, UL](ql: Quantity[VL, UL])
     inline def show: String = s"${ql.value.toString} ${showUnit[UL]}"
     inline def showFull: String = s"${ql.value.toString} ${showUnitFull[UL]}"
+
+    inline def toValue[V](using conv: ValueConversion[VL, V]): Quantity[V, UL] =
+        conv(ql.value).withUnit[UL]
+    inline def toUnit[U](using conv: UnitConversion[VL, UL, U]): Quantity[VL, U] =
+        conv(ql.value).withUnit[U]
 
     transparent inline def +[VR, UR](qr: Quantity[VR, UR])(using add: Add[VL, UL, VR, UR]): Quantity[add.VO, add.UO] =
         add(ql.value, qr.value).withUnit[add.UO]
@@ -101,17 +116,3 @@ extension[VL, UL](ql: Quantity[VL, UL])
 
     transparent inline def unary_-(using neg: Neg[VL, UL]): Quantity[VL, UL] =
         neg(ql.value).withUnit[UL]
-
-    transparent inline def toValue[V](using
-        conv: coulomb.conversion.ValueConversion[VL, V]): Quantity[V, UL] = conv(ql.value).withUnit[UL]
-    transparent inline def toUnit[U](using
-        conv: coulomb.conversion.UnitConversion[VL, UL, U]): Quantity[VL, U] = conv(ql.value).withUnit[U]
-
-inline def showUnit[U]: String = ${ coulomb.infra.show.show[U] }
-inline def showUnitFull[U]: String = ${ coulomb.infra.show.showFull[U] }
-
-/**
- * Obtain the coefficient of conversion from U1 -> U2
- * If U1 and U2 are not convertible, causes a compilation failure.
- */
-inline def coefficient[U1, U2]: Rational = ${ coulomb.infra.meta.coefficient[U1, U2] }

--- a/core/src/test/scala/coulomb/coefficient.scala
+++ b/core/src/test/scala/coulomb/coefficient.scala
@@ -22,32 +22,31 @@ class CoefficientSuite extends CoulombSuite:
     import coulomb.rational.Rational
 
     test("identical units") {
-        assert(summon[Coefficient[Meter, Meter]].value eq Rational.const1)
-        assert(summon[Coefficient[Liter, Liter]].value eq Rational.const1)
-        assert(summon[Coefficient[Kilogram * Meter / (Second ^ 2),
-                                  Kilogram * Meter / (Second ^ 2)]].value eq Rational.const1)
+        assert(coefficient[Meter, Meter] eq Rational.const1)
+        assert(coefficient[Liter, Liter] eq Rational.const1)
+        assert(coefficient[Kilogram * Meter / (Second ^ 2),
+                           Kilogram * Meter / (Second ^ 2)] eq Rational.const1)
     }
 
     test("convertible units") {
-        assert(summon[Coefficient[Meter, Yard]].value == Rational(10000, 9144))
-        assert(summon[Coefficient[Meter ^ 3, Liter]].value == 1000)
-        assert(summon[Coefficient[Kilogram * Meter / (Second ^ 2),
-                                  Pound * Yard / (Minute ^ 2)]].value == Rational(50000000000000L,5760623099L))
-        assert(summon[Coefficient[Meter ^ 3, 1000 * Liter]].value == 1)
-        assert(summon[Coefficient[Meter, Kilo * Yard]].value == Rational(10, 9144))
+        assertEquals(coefficient[Meter, Yard], Rational(10000, 9144))
+        assertEquals(coefficient[Meter ^ 3, Liter], Rational(1000))
+        assertEquals(coefficient[Kilogram * Meter / (Second ^ 2), Pound * Yard / (Minute ^ 2)],
+                     Rational(50000000000000L, 5760623099L))
+        assertEquals(coefficient[Meter ^ 3, 1000 * Liter], Rational(1))
+        assertEquals(coefficient[Meter, Kilo * Yard], Rational(10, 9144))
     }
-
     test("non-convertible units") {
-        assertCE("summon[Coefficient[Meter, Second]]")
-        assertCE("summon[Coefficient[Meter ^ 2, Liter]]")
-        assertCE("summon[Coefficient[Kilogram * Meter / (Second ^ 2), Pound * Yard / (Minute ^ 3)]]")
+        assertCE("coefficient[Meter, Second]")
+        assertCE("coefficient[Meter ^ 2, Liter]")
+        assertCE("coefficient[Kilogram * Meter / (Second ^ 2), Pound * Yard / (Minute ^ 3)]")
     }
 
     test("units with embedded coefficients") {
-        assert(summon[Coefficient[10 * Meter, Meter]].value == 10)
-        assert(summon[Coefficient[Meter, (1 / 3) * Meter]].value == 3)
-        assert(summon[Coefficient[(10 ^ 6) * Meter, Meter]].value == 1000000)
-        assert(summon[Coefficient[Meter,  1.5 * Meter]].value == Rational(2, 3))
-        assert(summon[Coefficient[Meter,  1.25f * Meter]].value == Rational(4, 5))
-        assert(summon[Coefficient[((1 / 3L) * (10L ^ 100)) * Meter, Meter]].value == Rational(1, 3) * Rational(10).pow(100))
+        assertEquals(coefficient[10 * Meter, Meter], Rational(10))
+        assertEquals(coefficient[Meter, (1 / 3) * Meter], Rational(3))
+        assertEquals(coefficient[(10 ^ 6) * Meter, Meter], Rational(1000000))
+        assertEquals(coefficient[Meter,  1.5 * Meter], Rational(2, 3))
+        assertEquals(coefficient[Meter,  1.25f * Meter], Rational(4, 5))
+        assertEquals(coefficient[((1 / 3L) * (10L ^ 100)) * Meter, Meter], Rational(1, 3) * Rational(10).pow(100))
     }


### PR DESCRIPTION
simplify `coefficient` to an inline function that returns a Rational directly
similarly simplify `show` and `showFull` to inline functions that return String directly
methods `toValue` and `toUnit` do not need to be `transparent`