### PR TITLE
Publish a unidoc artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/scala3')
-        run: mkdir -p target all/target units/.jvm/target .js/target core/.native/target site/target core/.js/target units/.native/target core/.jvm/target .jvm/target .native/target units/.js/target project/target
+        run: mkdir -p target all/target units/.jvm/target unidocs/target .js/target core/.native/target site/target core/.js/target units/.native/target core/.jvm/target .jvm/target .native/target units/.js/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/scala3')
-        run: tar cf targets.tar target all/target units/.jvm/target .js/target core/.native/target site/target core/.js/target units/.native/target core/.jvm/target .jvm/target .native/target units/.js/target project/target
+        run: tar cf targets.tar target all/target units/.jvm/target unidocs/target .js/target core/.native/target site/target core/.js/target units/.native/target core/.jvm/target .jvm/target .native/target units/.js/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/scala3')

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ def commonSettings = Seq(
 )
 
 lazy val root = tlCrossRootProject
-  .aggregate(core, units)
+  .aggregate(core, units, unidocs)
 
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -51,6 +51,12 @@ lazy val all = project
   .dependsOn(core.jvm, units.jvm) // scala repl only needs JVMPlatform subproj builds
   .settings(name := "coulomb-all")
   .enablePlugins(NoPublishPlugin) // don't publish
+
+// a published artifact aggregating API docs for viewing at javadoc.io
+lazy val unidocs = project
+  .in(file("unidocs")) // sbt will create this - it is unused
+  .settings(name := "coulomb-docs") // the name of the artifact
+  .enablePlugins(TypelevelUnidocPlugin) // enable Unidoc + publishing
 
 lazy val docs = project.in(file("site"))
   .enablePlugins(TypelevelSitePlugin)


### PR DESCRIPTION
This sets up a new published artifact `coulomb-docs` that contains the aggregated unidocs for the project.

javadoc.io doesn't render SNAPSHOT releases, so it won't do much until a real release. However I did preview locally and they look good!