### PR TITLE
make unit signatures List, clean up meta

### DIFF
--- a/core/src/main/scala/coulomb/infra/meta.scala
+++ b/core/src/main/scala/coulomb/infra/meta.scala
@@ -21,9 +21,6 @@ import coulomb.*
 import coulomb.define.*
 import coulomb.ops.*
 
-final type SNil
-final type %:[Head, Tail]
-
 object meta:
     import scala.quoted.*
     import scala.language.implicitConversions
@@ -125,7 +122,7 @@ object meta:
         // the fundamental algorithmic unit analysis criterion:
         // http://erikerlandson.github.io/blog/2019/05/03/algorithmic-unit-analysis/
         val (rcoef, rsig) = cansig(TypeRepr.of[/].appliedTo(List(u1, u2)))
-        if (rsig =:= TypeRepr.of[SNil]) then rcoef else
+        if (rsig == Nil) then rcoef else
             report.error(s"unit type ${typestr(u1)} not convertable to ${typestr(u2)}")
             Rational.const0
 
@@ -150,17 +147,17 @@ object meta:
     def convertible(using Quotes)(u1: quotes.reflect.TypeRepr, u2: quotes.reflect.TypeRepr): Boolean =
         import quotes.reflect.*
         val (_, rsig) = cansig(TypeRepr.of[/].appliedTo(List(u1, u2)))
-        rsig =:= TypeRepr.of[SNil]
+        rsig == Nil
 
     // returns tuple: (expr-for-coef, type-of-Res)
     def cansig(using Quotes)(u: quotes.reflect.TypeRepr):
-            (Rational, quotes.reflect.TypeRepr) =
+            (Rational, List[(quotes.reflect.TypeRepr, Rational)]) =
         import quotes.reflect.*
         // if this encounters a unit type pattern it cannot expand to a canonical signature,
         // at any level, it raises a compile-time error such that the context parameter search fails.
         u match
             // identify embedded coefficients (includes '1' aka unitless)
-            case unitconst(c) => (c, signil())
+            case unitconst(c) => (c, Nil)
             // traverse down the operator types first, since that can be done without
             // any attempts to look up context variables for BaseUnit and DerivedUnit,
             // which only happen at the leaves of expressions
@@ -177,25 +174,28 @@ object meta:
             case AppliedType(op, List(b, p)) if (op =:= TypeRepr.of[^]) =>
                 val (bcoef, bsig) = cansig(b)
                 val rationalTE(e) = p
-                if (e == 0) (Rational.const1, signil())
+                if (e == 0) (Rational.const1, Nil)
                 else if (e == 1) (bcoef, bsig)
                 else if (e.n.isValidInt && e.d.isValidInt)
                     val ucoef = if (e.d == 1) bcoef.pow(e.n.toInt)
                                 else bcoef.pow(e.n.toInt).root(e.d.toInt)
-                    val usig = unifyPow(p, bsig)
+                    val usig = unifyPow(e, bsig)
                     (ucoef, usig)
                 else
-                    { report.error(s"bad exponent in cansig: ${typestr(u)}"); csErr }
-            case baseunit() => (Rational.const1, sigcons(u, Rational.const1, signil()))
+                    report.error(s"bad exponent in cansig: ${typestr(u)}")
+                    (Rational.const0, Nil)
+            case baseunit() => (Rational.const1, (u, Rational.const1) :: Nil)
             case derivedunit(ucoef, usig) => (ucoef, usig)
             case _ if (!strictunitexprs) =>
                 // we consider any other type for "promotion" to base-unit only if
                 // it does not match the strict unit expression forms above, and
                 // if the strict unit expression policy has not been enabled
-                (Rational.const1, sigcons(u, Rational.const1, signil()))
-            case _ => { report.error(s"unknown unit expression in cansig: ${typestr(u)}"); csErr }
+                (Rational.const1, (u, Rational.const1) :: Nil)
+            case _ =>
+                report.error(s"unknown unit expression in cansig: ${typestr(u)}")
+                (Rational.const0, Nil)
 
-    def stdsig(using Quotes)(u: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr =
+    def stdsig(using Quotes)(u: quotes.reflect.TypeRepr): List[(quotes.reflect.TypeRepr, Rational)] =
         import quotes.reflect.*
         // if this encounters a unit type pattern it cannot expand,
         // at any level, it raises a compile-time error such that the context parameter search fails.
@@ -209,29 +209,29 @@ object meta:
                 unifyOp(stdsig(lu), stdsig(ru), _ - _)
             case AppliedType(op, List(b, p)) if (op =:= TypeRepr.of[^]) =>
                 val rationalTE(e) = p
-                if (e == 0) signil()
+                if (e == 0) Nil
                 else if (e == 1) stdsig(b)
-                else unifyPow(p, stdsig(b))
+                else unifyPow(e, stdsig(b))
             case unitconst(c) =>
-                if (c == 1) signil() else sigcons(rationalTE(c), Rational.const1, signil())
-            case baseunit() => sigcons(u, Rational.const1, signil())
-            case derivedunit(_, _) => sigcons(u, Rational.const1, signil())
+                if (c == 1) Nil else (rationalTE(c), Rational.const1) :: Nil
+            case baseunit() => (u, Rational.const1) :: Nil
+            case derivedunit(_, _) => (u, Rational.const1) :: Nil
             case _ if (!strictunitexprs) =>
                 // we consider any other type for "promotion" to base-unit only if
                 // it does not match the strict unit expression forms above, and
                 // if the strict unit expression policy has not been enabled
-                sigcons(u, Rational.const1, signil())
-            case _ => { report.error(s"unknown unit expression in stdsig: ${typestr(u)}"); signil() }
+                (u, Rational.const1) :: Nil
+            case _ =>
+                report.error(s"unknown unit expression in stdsig: ${typestr(u)}")
+                Nil
 
-    def sortsig(using Quotes)(sig: quotes.reflect.TypeRepr):
-            (quotes.reflect.TypeRepr, quotes.reflect.TypeRepr) =
-        import quotes.reflect.*
+    def sortsig(using Quotes)(sig: List[(quotes.reflect.TypeRepr, Rational)]):
+            (List[(quotes.reflect.TypeRepr, Rational)], List[(quotes.reflect.TypeRepr, Rational)]) =
         sig match
-            case signil() => (signil(), signil())
-            case sigcons(u, p, tail) =>
+            case Nil => (Nil, Nil)
+            case (u, e) :: tail =>
                 val (nsig, dsig) = sortsig(tail)
-                if (p > 0) (sigcons(u, p, nsig), dsig) else (nsig, sigcons(u, -p, dsig))
-            case _ => { report.error(s"unknown unit expression in stdsig: ${typestr(sig)}"); (signil(), signil()) }
+                if (e > 0) ((u, e) :: nsig, dsig) else (nsig, (u, -e) :: dsig)
 
     def simplifiedUnit[U](using Quotes, Type[U]): Expr[SimplifiedUnit[U]] =
         import quotes.reflect.*
@@ -247,16 +247,15 @@ object meta:
             case (unitconst1(), d) => TypeRepr.of[/].appliedTo(List(TypeRepr.of[1], d))
             case (n, d) => TypeRepr.of[/].appliedTo(List(n, d))
 
-    def uProd(using Quotes)(u: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr =
+    def uProd(using Quotes)(sig: List[(quotes.reflect.TypeRepr, Rational)]): quotes.reflect.TypeRepr =
         import quotes.reflect.*
-        u match
-            case signil() => TypeRepr.of[1]
-            case sigcons(u, p, signil()) => uTerm(u, p)
-            case sigcons(u1, p1, sigcons(u2, p2, signil())) =>
-                TypeRepr.of[*].appliedTo(List(uTerm(u1, p1), uTerm(u2, p2)))
-            case sigcons(u, p, tail) =>
-                TypeRepr.of[*].appliedTo(List(uTerm(u, p), uProd(tail)))
-            case _ => { report.error(s"unknown unit expression in uProd: ${typestr(u)}"); TypeRepr.of[Nothing] }
+        sig match
+            case Nil => TypeRepr.of[1]
+            case (u, e) :: Nil => uTerm(u, e)
+            case (u1, e1) :: (u2, e2) :: Nil =>
+                TypeRepr.of[*].appliedTo(List(uTerm(u1, e1), uTerm(u2, e2)))
+            case (u, e) :: tail =>
+                TypeRepr.of[*].appliedTo(List(uTerm(u, e), uProd(tail)))
 
     def uTerm(using Quotes)(u: quotes.reflect.TypeRepr, p: Rational): quotes.reflect.TypeRepr =
         import quotes.reflect.*
@@ -265,8 +264,8 @@ object meta:
     def strictunitexprs(using Quotes): Boolean =
         import quotes.reflect.*
         Implicits.search(TypeRepr.of[coulomb.policy.StrictUnitExpressions]) match
-                case _: ImplicitSearchSuccess => true
-                case _ => false
+            case _: ImplicitSearchSuccess => true
+            case _ => false
 
     object unitconst1:
         def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
@@ -288,13 +287,13 @@ object meta:
                 case _ => false
 
     object derivedunit:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Option[(Rational, quotes.reflect.TypeRepr)] =
+        def unapply(using Quotes)(u: quotes.reflect.TypeRepr):
+                Option[(Rational, List[(quotes.reflect.TypeRepr, Rational)])] =
             import quotes.reflect.*
             Implicits.search(TypeRepr.of[DerivedUnit].appliedTo(List(u, TypeBounds.empty, TypeBounds.empty, TypeBounds.empty))) match
                 case iss: ImplicitSearchSuccess =>
                     val AppliedType(_, List(_, d, _, _)) = iss.tree.tpe.baseType(TypeRepr.of[DerivedUnit].typeSymbol)
-                    val (dcoef, dsig) = cansig(d)
-                    Some((dcoef, dsig))
+                    Some(cansig(d))
                 case _ => None
 
     object deltaunit:
@@ -307,106 +306,35 @@ object meta:
                     Some((offset, b))
                 case _ => None
 
-    def csErr(using Quotes): (Rational, quotes.reflect.TypeRepr) =
-        (Rational.const0, quotes.reflect.TypeRepr.of[Nothing])
-
-    // keep this for reference
-    /*
-    def summonString[T](using Quotes, Type[T]): String =
-        import quotes.reflect.*
-        Expr.summon[T] match
-            case None => "None"
-            case Some(e) => s"${e.show}   ${e.asTerm.show(using Printer.TreeStructure)}"
-i   */
-
     def unifyOp(using Quotes)(
-            sig1: quotes.reflect.TypeRepr, sig2: quotes.reflect.TypeRepr,
-            op: (Rational, Rational) => Rational): quotes.reflect.TypeRepr =
-        import quotes.reflect.*
+        sig1: List[(quotes.reflect.TypeRepr, Rational)],
+        sig2: List[(quotes.reflect.TypeRepr, Rational)],
+        op: (Rational, Rational) => Rational
+            ): List[(quotes.reflect.TypeRepr, Rational)] =
         sig2 match
-            case signil() => sig1
-            case sigcons(u, e, tail) => unifyOp(insertTerm(u, e, sig1, op), tail, op)
-            case _ => { report.error(s"Unsupported type ${sig2.show}"); TypeRepr.of[Nothing] }
+            case Nil => sig1
+            case (u, e) :: tail => unifyOp(insertTerm(u, e, sig1, op), tail, op)
 
     def insertTerm(using Quotes)(
-            u: quotes.reflect.TypeRepr, e: Rational,
-            sig: quotes.reflect.TypeRepr,
-            op: (Rational, Rational) => Rational): quotes.reflect.TypeRepr =
-        import quotes.reflect.*
+        u: quotes.reflect.TypeRepr, e: Rational,
+        sig: List[(quotes.reflect.TypeRepr, Rational)],
+        op: (Rational, Rational) => Rational
+            ): List[(quotes.reflect.TypeRepr, Rational)] =
         sig match
-            case signil() => sigcons(u, op(Rational(0), e), signil())
-            case sigcons(u0, e0, tail) if (u =:= u0) => 
+            case Nil => (u, op(Rational.const0, e)) :: Nil
+            case (u0, e0) :: tail if (u =:= u0) =>
                 val ei = op(e0, e)
-                if (ei == 0) tail else sigcons(u, ei, tail)
-            case sigcons(u0, e0, tail) => sigcons(u0, e0, insertTerm(u, e, tail, op))
-            case _ => { report.error(s"Unsupported type ${sig.show}"); TypeRepr.of[Nothing] }
+                if (ei == Rational.const0) tail else (u, ei) :: tail
+            case (u0, e0) :: tail => (u0, e0) :: insertTerm(u, e, tail, op)
 
-    def unifyPow(using Quotes)(power: quotes.reflect.TypeRepr, sig: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr =
-        val rationalTE(e) = power
-        if (e == 0) signil() else unifyPowTerm(e, sig)
-
-    def unifyPowTerm(using Quotes)(e: Rational, sig: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr =
-        import quotes.reflect.*
+    def unifyPow(using Quotes)(
+        e: Rational,
+        sig: List[(quotes.reflect.TypeRepr, Rational)]
+            ): List[(quotes.reflect.TypeRepr, Rational)] =
         sig match
-            case signil() => signil()
-            case sigcons(u, e0, tail) => sigcons(u, e0 * e, unifyPowTerm(e, tail))
-            case _ => { report.error(s"Unsupported type ${sig.show}"); TypeRepr.of[Nothing] }
-
-    object signil:
-        def apply(using Quotes)(): quotes.reflect.TypeRepr = quotes.reflect.TypeRepr.of[SNil]
-
-        def unapply(using Quotes)(tr: quotes.reflect.TypeRepr): Boolean =
-            tr =:= quotes.reflect.TypeRepr.of[SNil]
-
-    object sigcons:
-        def apply(using Quotes)(u: quotes.reflect.TypeRepr, e: Rational, tail: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr =
-            sctc().appliedTo(List(t2tc().appliedTo(List(u, rationalTE(e))), tail))
-
-        def unapply(using Quotes)(tr: quotes.reflect.TypeRepr): Option[(quotes.reflect.TypeRepr, Rational, quotes.reflect.TypeRepr)] =
-            import quotes.reflect.*
-            tr match
-                case AppliedType(sctc(), List(AppliedType(t2tc(), List(u, rationalTE(e))), tail)) =>
-                    Some((u, e, tail))
-                case _ => None
-
-    object sctc:
-        def apply(using Quotes)(): quotes.reflect.TypeRepr = quotes.reflect.TypeRepr.of[%:]
-
-        def unapply(using Quotes)(tr: quotes.reflect.TypeRepr): Boolean =
-            tr =:= quotes.reflect.TypeRepr.of[%:]
-
-    object t2tc:
-        def apply(using Quotes)(): quotes.reflect.TypeRepr = quotes.reflect.TypeRepr.of[Tuple2]
-
-        def unapply(using Quotes)(tr: quotes.reflect.TypeRepr): Boolean =
-            tr =:= quotes.reflect.TypeRepr.of[Tuple2]
-
-    object strlt:
-        def unapply(using Quotes)(tr: quotes.reflect.TypeRepr): Option[String] =
-             import quotes.reflect.*
-             tr match
-                case ConstantType(StringConstant(v)) => Some(v)
-                case _ => None
-
-    object typeDouble:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
-            u =:= quotes.reflect.TypeRepr.of[Double]
-
-    object typeFloat:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
-            u =:= quotes.reflect.TypeRepr.of[Float]
-
-    object typeInt:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
-            u =:= quotes.reflect.TypeRepr.of[Int]
-
-    object typeLong:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
-            u =:= quotes.reflect.TypeRepr.of[Long]
-
-    object typeString:
-        def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =
-            u =:= quotes.reflect.TypeRepr.of[String]
+            case _ if (e == Rational.const0) => Nil
+            case Nil => Nil
+            case (u, e0) :: tail => (u, e0 * e) :: unifyPow(e, tail)
 
     def typestr(using Quotes)(t: quotes.reflect.TypeRepr): String =
         import quotes.reflect.*

--- a/core/src/main/scala/coulomb/infra/show.scala
+++ b/core/src/main/scala/coulomb/infra/show.scala
@@ -26,7 +26,7 @@ object show:
         import quotes.reflect.*
         val render = (tr: TypeRepr) => {
             val AppliedType(_, List(_, a)) = tr
-            val strlt(abbv) = a
+            val ConstantType(StringConstant(abbv)) = a
             abbv
         }
         val str = showrender(TypeRepr.of[U], render)
@@ -36,7 +36,7 @@ object show:
         import quotes.reflect.*
         val render = (tr: TypeRepr) => {
             val AppliedType(_, List(n, _)) = tr
-            val strlt(name) = n
+            val ConstantType(StringConstant(name)) = n
             name
         }
         val str = showrender(TypeRepr.of[U], render)


### PR DESCRIPTION
unit signature used to be a first-class type, with associated typeclasses, and so I used to manipulate it as a TypeRepr. However signatures have since evolved into an implementation detail in the metaprogramming, and so it is possible to simplify that representation and its implementation significantly by making it just List[(TypeRepr, Rational)]