### PR TITLE
Demonstrate issue with exported types

### DIFF
--- a/core/src/main/scala/coulomb/deltaquantity.scala
+++ b/core/src/main/scala/coulomb/deltaquantity.scala
@@ -16,7 +16,8 @@
 
 package coulomb
 
-export deltaquantity.DeltaQuantity as DeltaQuantity
+type DeltaQuantity[V, U, B] = deltaquantity.DeltaQuantity[V, U, B]
+val DeltaQuantity = deltaquantity.DeltaQuantity
 export deltaquantity.withDeltaUnit as withDeltaUnit
 
 object deltaquantity:

--- a/units/src/main/scala/coulomb/units/mks.scala
+++ b/units/src/main/scala/coulomb/units/mks.scala
@@ -25,8 +25,10 @@ object mks:
     export coulomb.units.si.{
         Meter, ctx_unit_Meter,
         Kilogram, ctx_unit_Kilogram,
-        Second, ctx_unit_Second
+        ctx_unit_Second
     }
+
+    type Second = coulomb.units.si.Second
 
     final type Radian
     given ctx_unit_Radian: DerivedUnit[Radian, 1, "radian", "rad"] with {}

--- a/units/src/main/scala/coulomb/units/time.scala
+++ b/units/src/main/scala/coulomb/units/time.scala
@@ -23,7 +23,8 @@ object time:
 
     import coulomb.*
 
-    export coulomb.units.si.{ Second, ctx_unit_Second }
+    type Second = coulomb.units.si.Second
+    export coulomb.units.si.ctx_unit_Second
 
     final type Minute
     given ctx_unit_Minute: DerivedUnit[Minute, 60 * Second, "minute", "min"] with {}

--- a/units/src/test/scala/coulomb/CompileSuite.scala
+++ b/units/src/test/scala/coulomb/CompileSuite.scala
@@ -1,0 +1,11 @@
+package coulomb
+
+import coulomb.*, coulomb.conversion.standard.all.given, coulomb.ops.standard.given, coulomb.ops.resolution.standard.given, algebra.instances.all.given, coulomb.ops.algebra.all.given, coulomb.units.mks.{*,given}, coulomb.rational.Rational, coulomb.units.mksa.{*,given}, coulomb.units.si.{*,given}, coulomb.units.temperature.{*, given}, coulomb.units.time.{*, given}
+import coulomb.testing.CoulombSuite
+
+class CompileSuite extends CoulombSuite:
+    test("compiler bug?") {
+        val res0 = 600.withEpochTime[Second]
+        val res1 = res0 - 100.withEpochTime[Second]
+        res0.show
+    }


### PR DESCRIPTION
Not for merging :)

This PR creates a test case with the compiler issue reported in https://github.com/erikerlandson/coulomb/discussions/237#discussioncomment-2411618.

Then, it fixes it by replacing exported types with type aliases.

So, either this is a compiler bug, or exporting types doesn't do what we'd expect 😅 