### PR TITLE
experiment with removing `transparent inline` from op definitions

### DIFF
--- a/core/src/main/scala/coulomb/ops/standard/pow.scala
+++ b/core/src/main/scala/coulomb/ops/standard/pow.scala
@@ -26,18 +26,19 @@ import coulomb.ops.{Pow, SimplifiedUnit}
 import coulomb.rational.typeexpr
 import coulomb.ops.algebra.FractionalPower
 
-transparent inline given ctx_pow_FractionalPower[V, U, E](using
+given ctx_pow_FractionalPower[V, U, E](using
     alg: FractionalPower[V],
+    dbv: typeexpr.DoubleValue[E],
     su: SimplifiedUnit[U ^ E]
         ): Pow[V, U, E] =
-    val e = typeexpr.double[E]
+    val e = dbv.value
     new Pow[V, U, E]:
         type VO = V
         type UO = su.UO
         def apply(q: Quantity[V, U]): Quantity[VO, UO] =
             alg.pow(q.value, e).withUnit[UO]
 
-transparent inline given ctx_pow_MultiplicativeGroup[V, U, E](using
+given ctx_pow_MultiplicativeGroup[V, U, E](using
     nfp: NotGiven[FractionalPower[V]],
     alg: MultiplicativeGroup[V],
     aie: typeexpr.AllInt[E],
@@ -50,7 +51,7 @@ transparent inline given ctx_pow_MultiplicativeGroup[V, U, E](using
         def apply(q: Quantity[V, U]): Quantity[VO, UO] =
             alg.pow(q.value, e).withUnit[UO]
 
-transparent inline given ctx_pow_MultiplicativeSemigroup[V, U, E](using
+given ctx_pow_MultiplicativeSemigroup[V, U, E](using
     nfp: NotGiven[FractionalPower[V]],
     nmg: NotGiven[MultiplicativeGroup[V]],
     alg: MultiplicativeSemigroup[V],

--- a/core/src/main/scala/coulomb/quantity.scala
+++ b/core/src/main/scala/coulomb/quantity.scala
@@ -117,7 +117,7 @@ object quantity:
         transparent inline def tquot[VR, UR](qr: Quantity[VR, UR])(using tq: TQuot[VL, UL, VR, UR]): Quantity[tq.VO, tq.UO] =
             tq(ql, qr)
 
-        transparent inline def pow[P](using pow: Pow[VL, UL, P]): Quantity[pow.VO, pow.UO] =
+        def pow[P](using pow: Pow[VL, UL, P]): Quantity[pow.VO, pow.UO] =
             pow(ql)
 
         transparent inline def tpow[P](using tp: TPow[VL, UL, P]): Quantity[tp.VO, tp.UO] =

--- a/core/src/main/scala/coulomb/rational/rational.scala
+++ b/core/src/main/scala/coulomb/rational/rational.scala
@@ -150,6 +150,16 @@ object typeexpr:
     inline def bigInt[E]: BigInt = ${ meta.teToBigInt[E] }
     inline def double[E]: Double = ${ meta.teToDouble[E] }
 
+
+    @implicitNotFound("type expr ${E} is not a Double")
+    abstract class DoubleValue[E]:
+        val value: Double
+
+    object DoubleValue:
+        transparent inline given ctx_DoubleValue[E]: DoubleValue[E] =
+            new DoubleValue[E]:
+                val value: Double = double[E]
+
     @implicitNotFound("type expr ${E} is not a non-negative Int")
     abstract class NonNegInt[E]:
         val value: Int


### PR DESCRIPTION
An experiment in removing `transparent inline` on operators.

This branch removes `transparent inline` from the `pow` method.