### PR TITLE
Physical constants

### DIFF
--- a/core/src/main/scala/coulomb/deltaquantity.scala
+++ b/core/src/main/scala/coulomb/deltaquantity.scala
@@ -16,10 +16,10 @@
 
 package coulomb
 
-export deltaquantity.DeltaQuantity
-export deltaquantity.withDeltaUnit
+export dqopaque.DeltaQuantity
+export dqopaque.withDeltaUnit
 
-object deltaquantity:
+object dqopaque:
     import coulomb.ops.*
     import coulomb.conversion.*
 
@@ -103,4 +103,4 @@ object deltaquantity:
         inline def >=[VR, UR](qr: DeltaQuantity[VR, UR, B])(using ord: DeltaOrd[B, VL, UL, VR, UR]): Boolean =
             ord(ql, qr) >= 0
     end extension
-end deltaquantity
+end dqopaque

--- a/core/src/main/scala/coulomb/infra/meta.scala
+++ b/core/src/main/scala/coulomb/infra/meta.scala
@@ -179,7 +179,11 @@ object meta:
     def simplify(using Quotes)(u: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr =
         import quotes.reflect.*
         given sigmode: SigMode = SigMode.Standard
-        val (un, ud) = sortsig(cansig(u)._2)
+        simplifysig(cansig(u)._2)
+
+    def simplifysig(using Quotes)(sig: List[(quotes.reflect.TypeRepr, Rational)]): quotes.reflect.TypeRepr =
+        import quotes.reflect.*
+        val (un, ud) = sortsig(sig)
         (uProd(un), uProd(ud)) match
             case (unitconst1(), unitconst1()) => TypeRepr.of[1]
             case (n, unitconst1()) => n

--- a/core/src/main/scala/coulomb/quantity.scala
+++ b/core/src/main/scala/coulomb/quantity.scala
@@ -42,10 +42,10 @@ inline def showUnitFull[U]: String = ${ coulomb.infra.show.showFull[U] }
  */
 inline def coefficient[U1, U2]: Rational = ${ coulomb.infra.meta.coefficient[U1, U2] }
 
-export quantity.Quantity
-export quantity.withUnit
+export qopaque.Quantity
+export qopaque.withUnit
 
-object quantity:
+object qopaque:
     opaque type Quantity[V, U] = V
 
     // lift
@@ -141,4 +141,4 @@ object quantity:
         inline def >=[VR, UR](qr: Quantity[VR, UR])(using ord: Ord[VL, UL, VR, UR]): Boolean =
             ord(ql, qr) >= 0
     end extension
-end quantity
+end qopaque

--- a/core/src/test/scala/coulomb/quantity.scala
+++ b/core/src/test/scala/coulomb/quantity.scala
@@ -449,7 +449,7 @@ class QuantitySuite extends CoulombSuite:
         (2.withUnit[Meter] * 3.withUnit[Meter * 1000]).assertQ[Int, (Meter ^ 2) * 1000](6)
 
         (5d.withUnit[((10 ^ 100)/3) * Meter] / 2d.withUnit[Second])
-            .assertQ[Double, ((10 ^ 100) * Meter) / (3 * Second)](2.5)
+            .assertQ[Double, (((10 ^ 100) / 3) * Meter) / Second](2.5)
     }
 
     test("negation standard") {

--- a/units/src/main/scala/coulomb/units/constants.scala
+++ b/units/src/main/scala/coulomb/units/constants.scala
@@ -17,8 +17,10 @@
 package coulomb.units
 
 /**
- * Physical constants as defined here:
+ * A selection of physical constants as defined in the following table:
  * https://en.wikipedia.org/wiki/List_of_physical_constants
+ * All units tagged as either "universal" or "frequently-used" in this table are defined.
+ * Other constant definitions can be included on request.
  */
 object constants:
     import coulomb.*
@@ -123,6 +125,10 @@ object constants:
     final type FineStructureConstant
     given ctx_unit_FineStructureConstant: DerivedUnit[FineStructureConstant, (72973525693L / (10 ^ 13)), "fine-structure-constant", "α"] = DerivedUnit()
 
+    /** Inverse fine structure constant: 137.035999084 */
+    final type InverseFineStructureConstant
+    given ctx_unit_InverseFineStructureConstant: DerivedUnit[InverseFineStructureConstant, (137035999084L / (10 ^ 9)), "inverse-fine-structure-constant", "α⁻ⁱ"] = DerivedUnit()
+
     /** Electron mass: 9.1093837015(28)×10−31 kg */
     final type ElectronMass
     given ctx_unit_ElectronMass: DerivedUnit[ElectronMass, (91093837015L / (10 ^ 41)) * Kilogram, "electron-mass", "mₑ"] = DerivedUnit()
@@ -154,6 +160,26 @@ object constants:
     /** electron volt: 1.602176634×10−19 J */
     final type ElectronVolt
     given ctx_unit_ElectronVolt: DerivedUnit[ElectronVolt, (1602176634L / (10 ^ 28)) * Joule, "electron-volt", "eV"] = DerivedUnit()
+
+    /** atomic mass constant: 1.66053906660(50)×10−27 kg */
+    final type AtomicMassConstant
+    given ctx_unit_AtomicMassConstant: DerivedUnit[AtomicMassConstant, (166053906660L / (10 ^ 38)) * Kilogram, "atomic-mass-constant", "mᵤ"] = DerivedUnit()
+
+    /** Faraday constant: 96485.33212... C/mol */
+    final type FaradayConstant
+    given ctx_unit_FaradayConstant: DerivedUnit[FaradayConstant, (9648533212L / (10 ^ 5)) * Coulomb / Mole, "faraday-constant", "F"] = DerivedUnit()
+
+    /** Molar gas constant: 8.314462618... J/(mol⋅K) */
+    final type MolarGasConstant
+    given ctx_unit_MolarGasConstant: DerivedUnit[MolarGasConstant, (8314462618L / (10 ^ 9)) * Joule / (Mole * Kelvin), "molar-gas-constant", "R"] = DerivedUnit()
+
+    /** Molar mass constant: 0.99999999965(30)×10−3 kg/mol */
+    final type MolarMassConstant
+    given ctx_unit_MolarMassConstant: DerivedUnit[MolarMassConstant, (99999999965L / (10 ^ 14)) * Kilogram / Mole, "molar-mass-constant", "Mᵤ"] = DerivedUnit()
+
+    /** Stefan-Boltzmann constant: 5.670374419...×10−8 W⋅m−2⋅K−4 */
+    final type StefanBoltzmannConstant
+    given ctx_unit_StefanBoltzmannConstant: DerivedUnit[StefanBoltzmannConstant, (5670374419L / (10 ^ 17)) * Watt / ((Meter ^ 2) * (Kelvin ^ 4)), "stefan-boltzmann-constant", "𝞼"] = DerivedUnit()
 
     object infra:
         abstract class ConstQ[CU]:

--- a/units/src/main/scala/coulomb/units/constants.scala
+++ b/units/src/main/scala/coulomb/units/constants.scala
@@ -48,13 +48,25 @@ object constants:
             ): Quantity[V, cq.QU] =
         vc(cq.value).withUnit[cq.QU]
 
-    /** Speed of light in a vacuum */
+    /** Speed of light in a vacuum: 299792458 m/s */
     final type SpeedOfLight
     given ctx_unit_SpeedOfLight: DerivedUnit[SpeedOfLight, 299792458 * Meter / Second, "speed-of-light", "c"] = DerivedUnit()
 
-    /** Planck's constant */
+    /** Planck's constant: 6.62607015×10−34 J⋅s */
     final type PlanckConstant
-    given ctx_unit_PlanckConstant: DerivedUnit[PlanckConstant, (662607015 * (10 ^ -42)) * Joule * Second, "planck-constant", "ℎ"] = DerivedUnit()
+    given ctx_unit_PlanckConstant: DerivedUnit[PlanckConstant, (662607015 / (10 ^ 42)) * Joule * Second, "planck-constant", "ℎ"] = DerivedUnit()
+
+    /** Reduced Planck Constant: 1.054571817×10−34 J⋅s */
+    final type ReducedPlanckConstant
+    given ctx_unit_ReducedPlanckConstant: DerivedUnit[ReducedPlanckConstant, (1054571817 / (10 ^ 43)) * Joule * Second, "reduced-planck-constant", "ℏ"] = DerivedUnit()
+
+    /** Newton's constant of gravitation: 6.67430(15)×10−11 m3⋅kg−1⋅s−2 */
+    final type GravitationalConstant
+    given ctx_unit_GravitationalConstant: DerivedUnit[GravitationalConstant, (667430 / (10 ^ 16)) * (Meter ^ 3) / (Kilogram * (Second ^ 2)), "gravitational-constant", "G"] = DerivedUnit()
+
+    /** Vacuum electric permittivity: 8.8541878128(13)×10−12 F/m */
+    final type VacuumElectricPermittivity
+    given ctx_unit_VacuumElectricPermittivity: DerivedUnit[VacuumElectricPermittivity, (88541878128L / (10 ^ 22)) * Farad / Meter, "vacuum-electric-permittivity", "ε₀"] = DerivedUnit() 
 
     object infra:
         abstract class ConstQ[CU]:

--- a/units/src/main/scala/coulomb/units/constants.scala
+++ b/units/src/main/scala/coulomb/units/constants.scala
@@ -27,6 +27,10 @@ object constants:
     import coulomb.conversion.ValueConversion
 
     export coulomb.units.mksa.{*, given}
+    export coulomb.units.si.{
+        Mole, ctx_unit_Mole,
+        Kelvin, ctx_unit_Kelvin
+    }
 
     /**
      * Obtain a Quantity representing a physical constant
@@ -67,6 +71,26 @@ object constants:
     /** Vacuum electric permittivity: 8.8541878128(13)×10−12 F/m */
     final type VacuumElectricPermittivity
     given ctx_unit_VacuumElectricPermittivity: DerivedUnit[VacuumElectricPermittivity, (88541878128L / (10 ^ 22)) * Farad / Meter, "vacuum-electric-permittivity", "ε₀"] = DerivedUnit() 
+
+    /** Vacuum magnetic permeability: 1.25663706212(19)×10−6 N⋅A−2 */
+    final type VacuumMagneticPermeability
+    given ctx_unit_VacuumMagneticPermeability: DerivedUnit[VacuumMagneticPermeability, (125663706212L / (10 ^ 17)) * Newton / (Ampere ^ 2), "vacuum-magnetic-permeability", "μ₀"] = DerivedUnit()
+
+    /** Characteristic impedance of vacuum: 376.730313668(57) Ω */
+    final type CharacteristicImpedanceOfVacuum
+    given ctx_unit_CharacteristicImpedanceOfVacuum: DerivedUnit[CharacteristicImpedanceOfVacuum, (376730313668L / (10 ^ 9)) * Ohm, "characteristic-impedance-of-vacuum", "Z₀"] = DerivedUnit()
+
+    /** The elementary charge: 1.602176634×10−19 C */
+    final type ElementaryCharge
+    given ctx_unit_ElementaryCharge: DerivedUnit[ElementaryCharge, (1602176634L / (10 ^ 28)) * Coulomb, "elementary-charge", "e"] = DerivedUnit()
+
+    /** Avogadro's number: 6.02214076×10+23 mol-1 */
+    final type AvogadroConstant
+    given ctx_unit_AvogadroConstant: DerivedUnit[AvogadroConstant, (602214076L * (10 ^ 15)) / Mole, "avogadro-constant", "Nₐ"] = DerivedUnit()
+
+    /** Boltzmann's constant: 1.380649×10−23 J⋅K−1 */
+    final type BoltzmannConstant
+    given ctx_unit_BoltzmannConstant: DerivedUnit[BoltzmannConstant, (1380649L / (10 ^ 29)) * Joule / Kelvin, "boltzmann-constant", "k"] = DerivedUnit()
 
     object infra:
         abstract class ConstQ[CU]:

--- a/units/src/main/scala/coulomb/units/constants.scala
+++ b/units/src/main/scala/coulomb/units/constants.scala
@@ -31,6 +31,9 @@ object constants:
         Mole, ctx_unit_Mole,
         Kelvin, ctx_unit_Kelvin
     }
+    export coulomb.units.si.prefixes.{
+        Giga, ctx_unit_Giga
+    }
 
     /**
      * Obtain a Quantity representing a physical constant
@@ -91,6 +94,66 @@ object constants:
     /** Boltzmann's constant: 1.380649×10−23 J⋅K−1 */
     final type BoltzmannConstant
     given ctx_unit_BoltzmannConstant: DerivedUnit[BoltzmannConstant, (1380649L / (10 ^ 29)) * Joule / Kelvin, "boltzmann-constant", "k"] = DerivedUnit()
+
+    /** Conductance quantum: 7.748091729...×10−5 S */
+    final type ConductanceQuantum
+    given ctx_unit_ConductanceQuantum: DerivedUnit[ConductanceQuantum, (7748091729L / (10 ^ 14)) * Siemens, "conductance-quantum", "G₀"] = DerivedUnit()
+
+    /** Josephson constant: 483597.8484...×10+9 Hz/V */
+    final type JosephsonConstant
+    given ctx_unit_JosephsonConstant: DerivedUnit[JosephsonConstant, (4835978484L * (10 ^ 5)) * Hertz / Volt, "josephson-constant", "Kⱼ"] = DerivedUnit()
+
+    /** Von Klitzing constant: 25812.80745... Ω */
+    final type VonKlitzingConstant
+    given ctx_unit_VonKlitzingConstant: DerivedUnit[VonKlitzingConstant, (2581280745L / (10 ^ 5)) * Ohm, "von-klitzing-constant", "Rₖ"] = DerivedUnit()
+
+    /** Magnetic flux quantum: 2.067833848...×10−15 Wb */
+    final type MagneticFluxQuantum
+    given ctx_unit_MagneticFluxQuantum: DerivedUnit[MagneticFluxQuantum, (2067833848L / (10 ^ 24)) * Weber, "magnetic-flux-quantum", "Φ₀"] = DerivedUnit()
+
+    /** Bohr magneton: 9.2740100783(28)×10−24 J/T */
+    final type BohrMagneton
+    given ctx_unit_BohrMagneton: DerivedUnit[BohrMagneton, (92740100783L / (10 ^ 34)) * Joule / Tesla, "bohr-magneton", "μB"] = DerivedUnit()
+
+    /** Nuclear magneton: 5.0507837461(15)×10−27 J/T */
+    final type NuclearMagneton
+    given ctx_unit_NuclearMagneton: DerivedUnit[NuclearMagneton, (50507837461L / (10 ^ 37)) * Joule / Tesla, "nuclear-magneton", "μₙ"] = DerivedUnit()
+
+    /** Fine structure constant: 7.2973525693(11)×10−3 */
+    final type FineStructureConstant
+    given ctx_unit_FineStructureConstant: DerivedUnit[FineStructureConstant, (72973525693L / (10 ^ 13)), "fine-structure-constant", "α"] = DerivedUnit()
+
+    /** Electron mass: 9.1093837015(28)×10−31 kg */
+    final type ElectronMass
+    given ctx_unit_ElectronMass: DerivedUnit[ElectronMass, (91093837015L / (10 ^ 41)) * Kilogram, "electron-mass", "mₑ"] = DerivedUnit()
+
+    /** Proton mass: 1.67262192369(51)×10−27 kg */
+    final type ProtonMass
+    given ctx_unit_ProtonMass: DerivedUnit[ProtonMass, (167262192369L / (10 ^ 38)) * Kilogram, "proton-mass", "mₚ"] = DerivedUnit()
+
+    /** Neutron mass: 1.67492749804(95)×10−27 kg */
+    final type NeutronMass
+    given ctx_unit_NeutronMass: DerivedUnit[NeutronMass, (167492749804L / (10 ^ 38)) * Kilogram, "neutron-mass", "mₚ"] = DerivedUnit()
+
+    /** Bohr radius: 5.29177210903(80)×10−11 m */
+    final type BohrRadius
+    given ctx_unit_BohrRadius: DerivedUnit[BohrRadius, (529177210903L / (10 ^ 22)) * Meter, "bohr-radius", "a₀"] = DerivedUnit()
+
+    /** Classical electron radius: 2.8179403262(13)×10−15 m */
+    final type ClassicalElectronRadius
+    given ctx_unit_ClassicalElectronRadius: DerivedUnit[ClassicalElectronRadius, (28179403262L / (10 ^ 25)) * Meter, "classical-electron-radius", "rₑ"] = DerivedUnit()
+
+    /** Electron g-factor: −2.00231930436256(35) */
+    final type ElectronGFactor
+    given ctx_unit_ElectronGFactor: DerivedUnit[ElectronGFactor, (-200231930436256L / (10 ^ 14)), "electron-g-factor", "rₑ"] = DerivedUnit()
+
+    /** Fermi coupling constant: 1.1663787(6)×10−5 GeV−2 */
+    final type FermiCouplingConstant
+    given ctx_unit_FermiCouplingConstant: DerivedUnit[FermiCouplingConstant, (11663787L / (10 ^ 12)) * ((Giga * ElectronVolt) ^ -2), "fermi-coupling-constant", "GF"] = DerivedUnit()
+
+    /** electron volt: 1.602176634×10−19 J */
+    final type ElectronVolt
+    given ctx_unit_ElectronVolt: DerivedUnit[ElectronVolt, (1602176634L / (10 ^ 28)) * Joule, "electron-volt", "eV"] = DerivedUnit()
 
     object infra:
         abstract class ConstQ[CU]:

--- a/units/src/main/scala/coulomb/units/constants.scala
+++ b/units/src/main/scala/coulomb/units/constants.scala
@@ -17,6 +17,7 @@
 package coulomb.units
 
 object constants:
+    import coulomb.*
     import coulomb.define.*
 
     import coulomb.units.si.{*, given}
@@ -26,5 +27,5 @@ object constants:
     given ctx_unit_SpeedOfLight: DerivedUnit[SpeedOfLight, 299792458 * Meter / Second, "speed-of-light", "c"] = DerivedUnit()
 
     final type PlanckConstant
-    given ctx_unit_PlanckConstant: DerivedUnit[PlanckConstant, (662607015 * (10 ^ -42)) * Joule * Second, "planck-constant", "ℎ"]
+    given ctx_unit_PlanckConstant: DerivedUnit[PlanckConstant, (662607015 * (10 ^ -42)) * Joule * Second, "planck-constant", "ℎ"] = DerivedUnit()
 

--- a/units/src/main/scala/coulomb/units/constants.scala
+++ b/units/src/main/scala/coulomb/units/constants.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Erik Erlandson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package coulomb.units
+
+object constants:
+    import coulomb.define.*
+
+    import coulomb.units.si.{*, given}
+    import coulomb.units.mksa.{*, given}
+
+    final type SpeedOfLight
+    given ctx_unit_SpeedOfLight: DerivedUnit[SpeedOfLight, 299792458 * Meter / Second, "speed-of-light", "c"] = DerivedUnit()
+
+    final type PlanckConstant
+    given ctx_unit_PlanckConstant: DerivedUnit[PlanckConstant, (662607015 * (10 ^ -42)) * Joule * Second, "planck-constant", "ℎ"]
+

--- a/units/src/test/scala/coulomb/constants.scala
+++ b/units/src/test/scala/coulomb/constants.scala
@@ -23,4 +23,7 @@ class ConstantsUnitsSuite extends CoulombSuite:
 
     test("physical constant values") {
         constant[Double, SpeedOfLight].assertQD[Double, Meter / Second](299792458)
+        constant[Double, PlanckConstant].assertQD[Double, Joule * Second](6.62607015e-34)
+        constant[Double, ElectronGFactor].assertQD[Double, 1](-2.00231930436256)
+        constant[Double, FermiCouplingConstant].assertQD[Double, 1 / ((Giga ^ 2) * (ElectronVolt ^ 2))](1.1663787e-5)
     }

--- a/units/src/test/scala/coulomb/constants.scala
+++ b/units/src/test/scala/coulomb/constants.scala
@@ -16,7 +16,7 @@
 
 import coulomb.testing.CoulombSuite
 
-class ConstantsUnitsSuite extends CoulombSuite:
+class PhysicalConstantsSuite extends CoulombSuite:
     import coulomb.*
     import coulomb.policy.standard.given
     import coulomb.units.constants.{*, given}
@@ -24,6 +24,33 @@ class ConstantsUnitsSuite extends CoulombSuite:
     test("physical constant values") {
         constant[Double, SpeedOfLight].assertQD[Double, Meter / Second](299792458)
         constant[Double, PlanckConstant].assertQD[Double, Joule * Second](6.62607015e-34)
+        constant[Double, ReducedPlanckConstant].assertQD[Double, Joule * Second](1.054571817e-34)
+        constant[Double, GravitationalConstant].assertQD[Double, (Meter ^ 3) / (Kilogram * (Second ^ 2))](6.67430e-11)
+        constant[Double, VacuumElectricPermittivity].assertQD[Double, Farad / Meter](8.8541878128e-12)
+        constant[Double, VacuumMagneticPermeability].assertQD[Double, Newton / (Ampere ^ 2)](1.25663706212e-6)
+        constant[Double, CharacteristicImpedanceOfVacuum].assertQD[Double, Ohm](376.730313668)
+        constant[Double, ElementaryCharge].assertQD[Double, Coulomb](1.602176634e-19)
+        constant[Double, AvogadroConstant].assertQD[Double, 1 / Mole](6.02214076e23)
+        constant[Double, BoltzmannConstant].assertQD[Double, Joule / Kelvin](1.380649e-23)
+        constant[Double, ConductanceQuantum].assertQD[Double, Siemens](7.748091729e-5)
+        constant[Double, JosephsonConstant].assertQD[Double, Hertz / Volt](483597.8484e9)
+        constant[Double, VonKlitzingConstant].assertQD[Double, Ohm](25812.80745)
+        constant[Double, MagneticFluxQuantum].assertQD[Double, Weber](2.067833848e-15)
+        constant[Double, BohrMagneton].assertQD[Double, Joule / Tesla](9.2740100783e-24)
+        constant[Double, NuclearMagneton].assertQD[Double, Joule / Tesla](5.0507837461e-27)
+        constant[Double, FineStructureConstant].assertQD[Double, 1](7.2973525693e-3)
+        constant[Double, InverseFineStructureConstant].assertQD[Double, 1](137.035999084)
+        constant[Double, ElectronMass].assertQD[Double, Kilogram](9.1093837015e-31)
+        constant[Double, ProtonMass].assertQD[Double, Kilogram](1.67262192369e-27)
+        constant[Double, NeutronMass].assertQD[Double, Kilogram](1.67492749804e-27)
+        constant[Double, BohrRadius].assertQD[Double, Meter](5.29177210903e-11)
+        constant[Double, ClassicalElectronRadius].assertQD[Double, Meter](2.8179403262e-15)
         constant[Double, ElectronGFactor].assertQD[Double, 1](-2.00231930436256)
         constant[Double, FermiCouplingConstant].assertQD[Double, 1 / ((Giga ^ 2) * (ElectronVolt ^ 2))](1.1663787e-5)
+        constant[Double, ElectronVolt].assertQD[Double, Joule](1.602176634e-19)
+        constant[Double, AtomicMassConstant].assertQD[Double, Kilogram](1.66053906660e-27)
+        constant[Double, FaradayConstant].assertQD[Double, Coulomb / Mole](96485.33212)
+        constant[Double, MolarGasConstant].assertQD[Double, Joule / (Mole * Kelvin)](8.314462618)
+        constant[Double, MolarMassConstant].assertQD[Double, Kilogram / Mole](0.99999999965e-3)
+        constant[Double, StefanBoltzmannConstant].assertQD[Double, Watt / ((Meter ^ 2) * (Kelvin ^ 4))](5.670374419e-8)
     }

--- a/units/src/test/scala/coulomb/constants.scala
+++ b/units/src/test/scala/coulomb/constants.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Erik Erlandson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import coulomb.testing.CoulombSuite
+
+class ConstantsUnitsSuite extends CoulombSuite:
+    import coulomb.*
+    import coulomb.policy.standard.given
+    import coulomb.units.constants.{*, given}
+
+    test("physical constant values") {
+        constant[Double, SpeedOfLight].assertQD[Double, Meter / Second](299792458)
+    }


### PR DESCRIPTION
@armanbilge   @cquiroz 

A concept for physical constants. The ergonomics looks like this:

```scala
Welcome to Scala 3.1.1 (11.0.14, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> import coulomb.*, algebra.instances.all.given, coulomb.ops.algebra.all.given, coulomb.policy.standard.given, coulomb.units.si.{*,given}, coulomb.units.si.prefixes.{*,given}, coulomb.units.mksa.{*,given}, coulomb.units.us.{*,given}, coulomb.define.*, coulomb.units.constants.{*,given}
                                                                                                                                            
scala> constq[SpeedOfLight]
val res0: 
  coulomb.quantity.Quantity[coulomb.rational.Rational, coulomb.units.si.Meter / 
    coulomb.units.si.Second
  ] = 299792458
                                                                                                                                            
scala> constq[PlanckConstant]
val res1: 
  coulomb.quantity.Quantity[coulomb.rational.Rational, coulomb.units.mksa.Joule 
    *
   coulomb.units.si.Second] = 132521403/200000000000000000000000000000000000000000
                                                                                                                                            
scala> res0.toValue[Double].show
val res2: String = 2.99792458E8 m/s
                                                                                                                                            
scala> res1.toValue[Double].show
val res3: String = 6.62607015E-34 J s
```