### PR TITLE
support lifted scalar values

### DIFF
--- a/core/src/main/scala/coulomb/conversion/standard/scala.scala
+++ b/core/src/main/scala/coulomb/conversion/standard/scala.scala
@@ -50,3 +50,7 @@ object scala:
         uc: DeltaUnitConversion[VT, B, UF, UT]
             ): Conversion[DeltaQuantity[VF, UF, B], DeltaQuantity[VT, UT, B]] =
         (q: DeltaQuantity[VF, UF, B]) => uc(vc(q.value)).withDeltaUnit[UT, B]
+
+    // also support implicit lift of values to unitless quantity
+    given ctx_Value_to_Unitless[V]: Conversion[V, Quantity[V, 1]] =
+        (v: V) => v.withUnit[1]

--- a/core/src/main/scala/coulomb/ops/algebra/all.scala
+++ b/core/src/main/scala/coulomb/ops/algebra/all.scala
@@ -17,7 +17,7 @@
 package coulomb.ops.algebra
 
 object all:
-    export coulomb.ops.algebra.int.{*,given}
-    export coulomb.ops.algebra.long.{*,given}
-    export coulomb.ops.algebra.float.{*,given}
-    export coulomb.ops.algebra.double.{*,given}
+    export coulomb.ops.algebra.int.{*, given}
+    export coulomb.ops.algebra.long.{*, given}
+    export coulomb.ops.algebra.float.{*, given}
+    export coulomb.ops.algebra.double.{*, given}

--- a/core/src/main/scala/coulomb/ops/algebra/double.scala
+++ b/core/src/main/scala/coulomb/ops/algebra/double.scala
@@ -18,6 +18,17 @@ package coulomb.ops.algebra
 
 import algebra.ring.TruncatedDivision
 
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
+
 object double:
     given ctx_Double_is_FractionalPower: FractionalPower[Double] =
         (v: Double, e: Double) => math.pow(v, e)
+
+    extension(vl: Double)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[Double, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Double, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/core/src/main/scala/coulomb/ops/algebra/float.scala
+++ b/core/src/main/scala/coulomb/ops/algebra/float.scala
@@ -18,6 +18,17 @@ package coulomb.ops.algebra
 
 import algebra.ring.TruncatedDivision
 
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
+
 object float:
     given ctx_Float_is_FractionalPower: FractionalPower[Float] =
         (v: Float, e: Double) => math.pow(v.toDouble, e).toFloat
+
+    extension(vl: Float)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[Float, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Float, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/core/src/main/scala/coulomb/ops/algebra/int.scala
+++ b/core/src/main/scala/coulomb/ops/algebra/int.scala
@@ -43,4 +43,3 @@ object int:
 
         transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Int, 1, VR, UR]): Quantity[div.VO, div.UO] =
             div.eval(vl.withUnit[1], qr)
-

--- a/core/src/main/scala/coulomb/ops/algebra/int.scala
+++ b/core/src/main/scala/coulomb/ops/algebra/int.scala
@@ -16,7 +16,11 @@
 
 package coulomb.ops.algebra
 
-import algebra.ring.TruncatedDivision
+import _root_.algebra.ring.TruncatedDivision
+
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
 
 object int:
     given ctx_Int_is_TruncatingPower: TruncatingPower[Int] with
@@ -29,7 +33,14 @@ object int:
         def fquot(x: Int, y: Int): Int = ???
         def fmod(x: Int, y: Int): Int = ???
         def abs(a: Int): Int = ???
-        def additiveCommutativeMonoid: algebra.ring.AdditiveCommutativeMonoid[Int] = ???
+        def additiveCommutativeMonoid: _root_.algebra.ring.AdditiveCommutativeMonoid[Int] = ???
         def order: _root_.cats.kernel.Order[Int] = ???
         def signum(a: Int): Int = ???
+
+    extension(vl: Int)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[Int, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Int, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)
 

--- a/core/src/main/scala/coulomb/ops/algebra/long.scala
+++ b/core/src/main/scala/coulomb/ops/algebra/long.scala
@@ -16,7 +16,11 @@
 
 package coulomb.ops.algebra
 
-import algebra.ring.TruncatedDivision
+import _root_.algebra.ring.TruncatedDivision
+
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
 
 object long:
     given ctx_Long_is_TruncatingPower: TruncatingPower[Long] with
@@ -29,6 +33,13 @@ object long:
         def fquot(x: Long, y: Long): Long = ???
         def fmod(x: Long, y: Long): Long = ???
         def abs(a: Long): Long = ???
-        def additiveCommutativeMonoid: algebra.ring.AdditiveCommutativeMonoid[Long] = ???
+        def additiveCommutativeMonoid: _root_.algebra.ring.AdditiveCommutativeMonoid[Long] = ???
         def order: _root_.cats.kernel.Order[Long] = ???
         def signum(a: Long): Int = ???
+
+    extension(vl: Long)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[Long, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Long, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/core/src/test/scala/coulomb/quantity.scala
+++ b/core/src/test/scala/coulomb/quantity.scala
@@ -21,7 +21,7 @@ class QuantitySuite extends CoulombSuite:
     import coulomb.syntax.*
     import coulomb.testing.units.{*, given}
     import algebra.instances.all.given
-    import coulomb.ops.algebra.all.given
+    import coulomb.ops.algebra.all.{*, given}
 
     test("lift via Quantity") {
         Quantity[Meter](3.14).assertQ[Double, Meter](3.14)
@@ -445,6 +445,23 @@ class QuantitySuite extends CoulombSuite:
         (-(7f.withUnit[Liter])).assertQ[Float, Liter](-7)
         (-(7L.withUnit[Liter])).assertQ[Long, Liter](-7)
         (-(7.withUnit[Liter])).assertQ[Int, Liter](-7)
+    }
+
+    test("mul and div by lifted unitless values") {
+        import coulomb.policy.standard.given
+        import scala.language.implicitConversions
+
+        val q = 2.withUnit[Meter]
+
+        // left-hand arguments have to be defined on per type basis
+        // I did this in coulomb.ops.algebra.{double, float, etc}
+        (2.0 * q).assertQ[Double, Meter](4.0)
+        (2.0 / q).assertQ[Double, 1 / Meter](1.0)
+
+        // right-hand arguments require implicit conversion
+        // I defined in coulomb.conversion.standard.scala
+        (q * 2.0).assertQ[Double, Meter](4.0)
+        (q / 2.0).assertQ[Double, Meter](1.0)
     }
 
     test("equality strict") {

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ import coulomb.ops.algebra.all.given
 
 // unit and value type policies for operations
 import coulomb.policy.standard.given
+import scala.language.implicitConversions
 
 // unit definitions
 import coulomb.units.si.{*, given}
@@ -45,7 +46,7 @@ val t = 10.withUnit[Second]
 val v = a * t
 
 // position
-val x = a * (t.pow[2]) / 2.withUnit[1]
+val x = a * (t.pow[2]) / 2
 ```
 
 Improper unit analysis is a compile-time failure.

--- a/spire/src/main/scala/coulomb/ops/algebra/spire/algebraic.scala
+++ b/spire/src/main/scala/coulomb/ops/algebra/spire/algebraic.scala
@@ -16,6 +16,10 @@
 
 package coulomb.ops.algebra.spire
 
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
+
 object algebraic:
     import _root_.spire.math.*
     import coulomb.ops.algebra.*
@@ -30,3 +34,9 @@ object algebraic:
         val bf = summon[Fractional[BigDecimal]]
         (v: Algebraic, e: Double) => b2a(bf.fpow(a2b(v), e))
 
+    extension(vl: Algebraic)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[Algebraic, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Algebraic, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/spire/src/main/scala/coulomb/ops/algebra/spire/all.scala
+++ b/spire/src/main/scala/coulomb/ops/algebra/spire/all.scala
@@ -18,10 +18,10 @@ package coulomb.ops.algebra.spire
 
 object all:
     // this is a supserset of algebras provided by coulomb-core
-    export coulomb.ops.algebra.all.given
+    export coulomb.ops.algebra.all.{*, given}
 
-    export rational.given
-    export bigdecimal.given
-    export algebraic.given
-    export real.given
-    export bigint.given
+    export rational.{*, given}
+    export bigdecimal.{*, given}
+    export algebraic.{*, given}
+    export real.{*, given}
+    export bigint.{*, given}

--- a/spire/src/main/scala/coulomb/ops/algebra/spire/bigdecimal.scala
+++ b/spire/src/main/scala/coulomb/ops/algebra/spire/bigdecimal.scala
@@ -16,6 +16,10 @@
 
 package coulomb.ops.algebra.spire
 
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
+
 object bigdecimal:
     import _root_.spire.math.*
     import coulomb.ops.algebra.*
@@ -24,3 +28,9 @@ object bigdecimal:
         (v: BigDecimal, e: Double) =>
             summon[Fractional[BigDecimal]].fpow(v, e)
 
+    extension(vl: BigDecimal)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[BigDecimal, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[BigDecimal, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/spire/src/main/scala/coulomb/ops/algebra/spire/bigint.scala
+++ b/spire/src/main/scala/coulomb/ops/algebra/spire/bigint.scala
@@ -16,8 +16,12 @@
 
 package coulomb.ops.algebra.spire
 
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
+
 object bigint:
-    import algebra.ring.TruncatedDivision
+    import _root_.algebra.ring.TruncatedDivision
     import _root_.spire.math.*
     import coulomb.ops.algebra.*
 
@@ -32,6 +36,13 @@ object bigint:
         def fquot(x: BigInt, y: BigInt): BigInt = ???
         def fmod(x: BigInt, y: BigInt): BigInt = ???
         def abs(a: BigInt): BigInt = ???
-        def additiveCommutativeMonoid: algebra.ring.AdditiveCommutativeMonoid[BigInt] = ???
+        def additiveCommutativeMonoid: _root_.algebra.ring.AdditiveCommutativeMonoid[BigInt] = ???
         def order: _root_.cats.kernel.Order[BigInt] = ???
         def signum(a: BigInt): Int = ???
+
+    extension(vl: BigInt)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[BigInt, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[BigInt, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/spire/src/main/scala/coulomb/ops/algebra/spire/rational.scala
+++ b/spire/src/main/scala/coulomb/ops/algebra/spire/rational.scala
@@ -16,6 +16,10 @@
 
 package coulomb.ops.algebra.spire
 
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
+
 object rational:
     import _root_.spire.math.*
     import coulomb.ops.algebra.*
@@ -24,3 +28,10 @@ object rational:
         (v: Rational, e: Double) =>
             if (e.isValidInt) v.pow(e.toInt)
             else summon[Fractional[Rational]].fpow(v, e)
+
+    extension(vl: Rational)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[Rational, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
+
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Rational, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/spire/src/main/scala/coulomb/ops/algebra/spire/real.scala
+++ b/spire/src/main/scala/coulomb/ops/algebra/spire/real.scala
@@ -16,6 +16,10 @@
 
 package coulomb.ops.algebra.spire
 
+import coulomb.*
+import coulomb.syntax.*
+import coulomb.ops.*
+
 object real:
     import _root_.spire.math.*
     import coulomb.ops.algebra.*
@@ -24,4 +28,9 @@ object real:
         (v: Real, e: Double) =>
             summon[Fractional[Real]].fpow(v, e)
 
+    extension(vl: Real)
+        transparent inline def *[VR, UR](qr: Quantity[VR, UR])(using mul: Mul[Real, 1, VR, UR]): Quantity[mul.VO, mul.UO] =
+            mul.eval(vl.withUnit[1], qr)
 
+        transparent inline def /[VR, UR](qr: Quantity[VR, UR])(using div: Div[Real, 1, VR, UR]): Quantity[div.VO, div.UO] =
+            div.eval(vl.withUnit[1], qr)

--- a/spire/src/test/scala/coulomb/quantity.scala
+++ b/spire/src/test/scala/coulomb/quantity.scala
@@ -22,7 +22,7 @@ class SpireQuantitySuite extends CoulombSuite:
     import coulomb.syntax.*
 
     import algebra.instances.all.given
-    import coulomb.ops.algebra.spire.all.given
+    import coulomb.ops.algebra.spire.all.{*, given}
 
     import coulomb.units.si.{*, given}
     import coulomb.units.si.prefixes.{*, given}
@@ -139,6 +139,19 @@ class SpireQuantitySuite extends CoulombSuite:
         BigInt(10).withUnit[Meter].tpow[-1].assertQ[BigInt, 1 / Meter](BigInt(0))
         BigInt(10).withUnit[Meter].tpow[1 / 2].assertQ[BigInt, Meter ^ (1 / 2)](BigInt(3))
         BigInt(10).withUnit[Meter].tpow[-1 / 2].assertQ[BigInt, 1 / (Meter ^ (1 / 2))](BigInt(0))
+    }
+
+    test("mul and div by lifted unitless values") {
+        import coulomb.policy.spire.standard.given
+        import scala.language.implicitConversions
+
+        val q = 2.withUnit[Meter]
+
+        (Rational(2) * q).assertQ[Rational, Meter](4)
+        (Rational(2) / q).assertQ[Rational, 1 / Meter](1)
+
+        (q * Rational(2)).assertQ[Rational, Meter](4)
+        (q / Rational(2)).assertQ[Rational, Meter](1)
     }
 
     test("< strict") {


### PR DESCRIPTION
fixes #211

cc @cquiroz  @armanbilge 

Handling left and right hand "raw" (aka scalar) values requires different mechanisms.  This bit of asymmetry is annoying but I don't currently see a way around it. In scala2 I couldn't get it working at all, so it's an improvement.