### PR TITLE
remove strictUnitExprs policy

### DIFF
--- a/core/src/main/scala/coulomb/infra/meta.scala
+++ b/core/src/main/scala/coulomb/infra/meta.scala
@@ -176,14 +176,9 @@ object meta:
             case derivedunit(ucoef, usig) => mode match
                 case SigMode.Canonical => (ucoef, usig)
                 case _ => (Rational.const1, (u, Rational.const1) :: Nil)
-            case _ if (!strictunitexprs) =>
-                // we consider any other type for "promotion" to base-unit only if
-                // it does not match the strict unit expression forms above, and
-                // if the strict unit expression policy has not been enabled
-                (Rational.const1, (u, Rational.const1) :: Nil)
             case _ =>
-                report.error(s"unknown unit expression in cansig: ${typestr(u)}")
-                (Rational.const0, Nil)
+                // treat any other type as if it were a BaseUnit
+                (Rational.const1, (u, Rational.const1) :: Nil)
 
     def sortsig(using Quotes)(sig: List[(quotes.reflect.TypeRepr, Rational)]):
             (List[(quotes.reflect.TypeRepr, Rational)], List[(quotes.reflect.TypeRepr, Rational)]) =
@@ -220,12 +215,6 @@ object meta:
     def uTerm(using Quotes)(u: quotes.reflect.TypeRepr, p: Rational): quotes.reflect.TypeRepr =
         import quotes.reflect.*
         if (p == 1) u else TypeRepr.of[^].appliedTo(List(u, rationalTE(p)))
-
-    def strictunitexprs(using Quotes): Boolean =
-        import quotes.reflect.*
-        Implicits.search(TypeRepr.of[coulomb.policy.infra.StrictUnitExpressions]) match
-            case _: ImplicitSearchSuccess => true
-            case _ => false
 
     object unitconst1:
         def unapply(using Quotes)(u: quotes.reflect.TypeRepr): Boolean =

--- a/core/src/main/scala/coulomb/infra/show.scala
+++ b/core/src/main/scala/coulomb/infra/show.scala
@@ -64,10 +64,9 @@ object show:
             case AppliedType(op, List(b, e)) if (op =:= TypeRepr.of[^]) =>
                 val (bs, es) = (paren(b, render), powstr(e))
                 s"${bs}^${es}"
-            case _ if (!strictunitexprs) => typestr(u)
-            case _ =>
-                report.error(s"unrecognized unit pattern $u")
-                ""
+            // treat any other type as if it is a BaseUnit,
+            // with its name and abbv defined as its type-string
+            case _ => typestr(u)
 
     def termstr(using Quotes)(terms: List[quotes.reflect.TypeRepr], render: quotes.reflect.TypeRepr => String): String =
         import quotes.reflect.*

--- a/core/src/main/scala/coulomb/policy.scala
+++ b/core/src/main/scala/coulomb/policy.scala
@@ -89,23 +89,3 @@ object strict:
     export coulomb.conversion.standard.value.given
     export coulomb.conversion.standard.unit.given
     export coulomb.ops.algebra.cats.all.given
-
-/**
- * By default, coulomb will treat any unrecognized type as a base unit.
- * To disable this behavior and raise a compile error on any type not declared as
- * a BaseUnit, DerivedUnit, etc:
- *
- * {{{
- * import coulomb.policy.strictUnitExpressions.given
- * }}}
- */
-object strictUnitExpressions:
-    import coulomb.policy.infra.StrictUnitExpressions
-    given ctx_StrictUnitExpressions: StrictUnitExpressions with {}
-
-object infra:
-    /**
-     * When a context variable of this type is in scope, coulomb will raise a compile error
-     * if it encounters a type not declared as a unit.
-     */
-    sealed trait StrictUnitExpressions

--- a/core/src/test/scala/coulomb/coefficient.scala
+++ b/core/src/test/scala/coulomb/coefficient.scala
@@ -51,14 +51,3 @@ class CoefficientSuite extends CoulombSuite:
         assertEquals(coefficient[Meter,  1.25f * Meter], Rational(4, 5))
         assertEquals(coefficient[((1 / 3L) * (10L ^ 100)) * Meter, Meter], Rational(1, 3) * Rational(10).pow(100))
     }
-
-    test("strict unit expressions") {
-        // by default, coulomb allows any type to behave like a base-unit
-        assertEquals(coefficient[Kilo * String, String], Rational(1000))
-        object t:
-            // strict unit expresion policy forbids types not explicitly defined as units
-            import coulomb.policy.strictUnitExpressions.given
-            assertCE("coefficient[Kilo * String, String]")
-            // explicitly defined units are OK
-            assertEquals(coefficient[Meter, Kilo * Yard], Rational(10, 9144))
-    }


### PR DESCRIPTION
Correctly implementing everywhere this would impact more code than I really want, and simply always allowing arbitrary types is not likely to hurt anyone.